### PR TITLE
Rework knot selection to be part of undo/redo 

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -6,4 +6,5 @@
          "resources"]
  :deps  {org.clj-commons/pretty     {:mvn/version "3.2.0"}
          org.clj-commons/humanize   {:mvn/version "1.1"}
+         medley/medley              {:mvn/version "1.4.0"}
          io.github.hlship/cli-tools {:mvn/version "0.14"}}}

--- a/deps.edn
+++ b/deps.edn
@@ -10,6 +10,7 @@
          org.clj-commons/pretty     {:mvn/version "3.2.0"}
          org.clj-commons/humanize   {:mvn/version "1.1"}
          io.github.hlship/cli-tools {:mvn/version "0.14"}
+         medley/medley              {:mvn/version "1.4.0"}
          ;; Bundled Babashka dependencies:
          selmer/selmer              {:mvn/version "1.12.61"}
          babashka/fs                {:mvn/version "0.5.22"}

--- a/skein-ui/src/App.svelte
+++ b/skein-ui/src/App.svelte
@@ -62,12 +62,10 @@
       knots.delete(id);
     }
 
-    if (result.selected) {
-      await jumpTo(result.selected);
-    }
-
     enableUndo = result.enable_undo;
     enableRedo = result.enable_redo;
+
+    await jumpTo(result.selected);
   }
 
   function knotNode(id: number): KnotNode {
@@ -152,13 +150,8 @@
 
   let newCommand;
 
-  function focusNewCommand(id: number) {
-    // id should be visible, this truncates the display list to that id
-    // such that the new command will be a child of the id.
-    // id2selected.delete(id);
-    // TODO: This should route through server
-
-    newCommand.focus();
+  async function focusNewCommand(id: number) : Promise<void> {
+    postPayload({action: "deselect", id: id})
   }
 </script>
 

--- a/skein-ui/src/App.svelte
+++ b/skein-ui/src/App.svelte
@@ -4,10 +4,10 @@
   import ReplayAllModal from "./lib/ReplayAllModal.svelte";
   import ModalAlert from "./lib/ModalAlert.svelte";
   import { onMount, tick } from "svelte";
-  import { load, category, postApi } from "./lib/common.svelte";
+  import { load, postApi } from "./lib/common.svelte";
   import * as d from "./lib/derived.svelte";
   import { SvelteMap } from "svelte/reactivity";
-  import { type KnotData, type KnotNode, Category } from "./lib/types";
+  import { type KnotData, type KnotNode } from "./lib/types";
   import { type ActionResult, type Payload } from "./lib/common.svelte";
   import {
     Button,
@@ -26,12 +26,10 @@
   } from "flowbite-svelte-icons";
 
   let knots = new SvelteMap<number, KnotData>();
-  let id2selected = new SvelteMap<number, number>();
 
   let knotTotals = $derived(d.deriveKnotTotals(knots));
-  let displayIds = $derived(d.deriveDisplayIds(knots, id2selected));
-
-  let id2category = $derived(d.deriveKnotCategory(knots));
+  let displayIds = $derived(d.deriveDisplayIds(knots));
+  let id2TreeCategory = $derived(d.deriveId2TreeCategory(knots));
 
   // This is provided to the NewCommand component because any new command is created as a child of that.
   let lastSelectedKnotId = $derived(displayIds[displayIds.length - 1]);
@@ -50,26 +48,22 @@
     modalAlertRunning = true;
   }
 
-  function processResult(result: ActionResult): void {
+  async function processResult(result: ActionResult): Promise<void> {
     // The Svelte4 code did all the updates in a single block, to minimize
     // the number of derived calculations; trusting that Svelte5 is smart about this.
     for (const knot of result.updates) {
       knots.set(knot.id, knot);
-      if (!loaded) {
-        id2selected.set(knot.id, knot.children[0]);
-      }
     }
 
     // When a node is deleted, check its parent node's selected child;
     // If they match, then delete the parent node's selected.
 
     for (const id of result.removed_ids) {
-      let parent_id = knots.get(id)?.parent_id;
-
-      if (id2selected.get(parent_id) == id) {
-        id2selected.delete(parent_id);
-      }
       knots.delete(id);
+    }
+
+    if (result.selected) {
+      await jumpTo(result.selected);
     }
 
     enableUndo = result.enable_undo;
@@ -82,15 +76,13 @@
     return {
       id,
       data,
-      category: category(data),
-      treeCategory: id2category.get(id) || Category.OK,
-      selectedChildId: id2selected.get(id),
+      treeCategory: id2TreeCategory.get(id) || "ok",
       children: data.children.map((childId) => {
         const child = knots.get(childId);
         return {
           id: childId,
           label: child.command,
-          treeCategory: id2category.get(childId) || Category.OK,
+          treeCategory: id2TreeCategory.get(childId) || "ok",
         };
       }),
     };
@@ -132,33 +124,29 @@
     replayAllModal.run();
   }
 
-  function selectKnot(id: number): void {
-    let childId = id;
-    while (childId != undefined) {
-      const knot = knots.get(childId);
-      const parentId = knot.parent_id;
-
-      id2selected.set(parentId, childId);
-
-      childId = parentId;
-    }
+  async function selectKnot(id: number): Promise<void> {
+    await postPayload({ action: "select", id: id });
   }
 
-  async function jumpTo(knotId) {
+  async function jumpTo(knotId): Promise<void> {
+    const knot = knots.get(knotId);
+
+    // When selecting a knot with no children, or no selected child, then focus on the newCommand
+    // to let the user enter a command.
+    if (!knot.selected) {
+      newCommand.focus();
+      return;
+    }
+
     // Wasn't happy about this before, even less so w/ Svelte5.
     let elementId = `knot_${knotId}`;
     let element = document.getElementById(elementId);
 
-    if (element == undefined) {
-      selectKnot(knotId);
-
-      while (element == undefined) {
-        await tick();
-        element = document.getElementById(elementId);
-      }
+    while (element == undefined) {
+      await tick();
+      element = document.getElementById(elementId);
     }
 
-    // TODO: If the element has no children, then scroll to the command input field instead.
     element.scrollIntoView({ behavior: "smooth", block: "end" });
   }
 
@@ -167,7 +155,8 @@
   function focusNewCommand(id: number) {
     // id should be visible, this truncates the display list to that id
     // such that the new command will be a child of the id.
-    id2selected.delete(id);
+    // id2selected.delete(id);
+    // TODO: This should route through server
 
     newCommand.focus();
   }
@@ -186,13 +175,13 @@
     </NavBrand>
     <div class="mx-0 inline-flex">
       <div class="text-black bg-green-400 p-2 font-semibold rounded-l-lg">
-        {knotTotals.get(Category.OK)}
+        {knotTotals.ok}
       </div>
       <div class="text-black bg-yellow-200 p-2 font-semibold">
-        {knotTotals.get(Category.NEW)}
+        {knotTotals.new}
       </div>
       <div class="text-black bg-red-500 p-2 font-semibold rounded-r-lg">
-        {knotTotals.get(Category.ERROR)}
+        {knotTotals.error}
       </div>
       <Button class="ml-8" color="blue" size="xs"
         >Jump <ChevronDownOutline /></Button

--- a/skein-ui/src/lib/EditProperty.svelte
+++ b/skein-ui/src/lib/EditProperty.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { tick, type Snippet } from "svelte";
+    import { tick } from "svelte";
     import { Modal, Alert } from "flowbite-svelte";
     import { ExclamationCircleSolid } from "flowbite-svelte-icons";
 

--- a/skein-ui/src/lib/Knot.svelte
+++ b/skein-ui/src/lib/Knot.svelte
@@ -9,13 +9,16 @@
 
     interface Props {
         knot: KnotNode;
-        processResult: (result: ActionResult) => Promise<void>;
+        scrollTo: boolean;
+        processResult: (result: ActionResult) => void;
         selectKnot: (id: number) => Promise<void>;
         focusNewCommand: (id: number) => Promise<void>;
         alert: (message: string) => void;
     }
 
-    let { knot, processResult, selectKnot, focusNewCommand, alert }: Props =
+    let { knot, processResult, selectKnot, focusNewCommand, alert,
+        scrollTo
+     }: Props =
         $props();
 
     let blessEnabled = $derived(knot.data.category != "ok");
@@ -118,7 +121,7 @@
         });
     }
 
-    async function onInsertParent(newCommand: string) {
+    async function onInsertParent(newCommand: string) : Promise<boolean> {
         const result = await post({
             action: "insert-parent",
             id: knot.id,
@@ -130,16 +133,21 @@
             return false;
         }
 
-        // This should recalculate the displayed knots to include the new parent
-        selectKnot(knot.id);
-
         return true;
     }
 
     const ddcolor = "hover:bg-slate-200";
+
+    var outerDiv;
+
+    $effect(() => {
+        if (scrollTo && outerDiv) {
+            outerDiv.scrollIntoView({ behavior: "smooth", block: "end" });
+        }
+    });
 </script>
 
-<div class="border-x-4 {knotColor.border}" id="knot_{knot.id}">
+<div class="border-x-4 {knotColor.border}" bind:this={outerDiv}>
     <KnotText response={knot.data.response} unblessed={knot.data.unblessed}>
         {#snippet actions()}
             <div

--- a/skein-ui/src/lib/Knot.svelte
+++ b/skein-ui/src/lib/Knot.svelte
@@ -5,28 +5,31 @@
     import KnotText from "./KnotText.svelte";
     import EditProperty from "./EditProperty.svelte";
     import { DotsVerticalOutline, CodeMergeSolid } from "flowbite-svelte-icons";
-    import { Category, type KnotNode } from "./types";
+    import { type KnotNode } from "./types";
 
     interface Props {
-        knot: KnotNode,
-        processResult: (result: ActionResult) => void,
-        selectKnot: (id: number) => void,
-        focusNewCommand: (id: number) => void,
-        alert: (message:string) => void
+        knot: KnotNode;
+        processResult: (result: ActionResult) => Promise<void>;
+        selectKnot: (id: number) => Promise<void>;
+        focusNewCommand: (id: number) => Promise<void>;
+        alert: (message: string) => void;
     }
 
-    let { knot, processResult, selectKnot, focusNewCommand, alert }: Props = $props();
+    let { knot, processResult, selectKnot, focusNewCommand, alert }: Props =
+        $props();
 
-    let blessEnabled = $derived(knot.category != Category.OK);
-    let blessClass = $derived(blessEnabled ? null : "text-gray-600 cursor-not-allowed");
+    let blessEnabled = $derived(knot.data.category != "ok");
+    let blessClass = $derived(
+        blessEnabled ? null : "text-gray-600 cursor-not-allowed",
+    );
     let editLabel, editCommand, insertParent;
 
-    let knotColor = $derived(category2color.get(knot.category));
-    let controlColor = $derived(category2color.get(knot.treeCategory));
+    let knotColor = $derived(category2color[knot.data.category]);
+    let controlColor = $derived(category2color[knot.treeCategory]);
 
     let actionDropdownOpen = $state(false);
     let childDropdownOpen = $state(false);
-    let error : string = $state(null);
+    let error: string = $state(null);
 
     async function post(payload: Payload): Promise<ActionResult> {
         actionDropdownOpen = false;
@@ -70,165 +73,178 @@
         focusNewCommand(knot.id);
     }
 
-    async function onEditLabel(newLabel : string) {
+    async function onEditLabel(newLabel: string) {
         post({ action: "label", id: knot.id, label: newLabel });
 
         return true;
     }
 
-function activateField(field) {
-    actionDropdownOpen = false;
-    error = null;
-    field.activate()   ; 
-}
-
-async function completeEditProperty(payload : Payload) : Promise<boolean> {
-    const result = await post(payload);
-
-    if (result.error) {
-        error = result.error;
-        return false;
+    function activateField(field) {
+        actionDropdownOpen = false;
+        error = null;
+        field.activate();
     }
 
-    return true;
-}
+    async function completeEditProperty(payload: Payload): Promise<boolean> {
+        const result = await post(payload);
 
-async function spliceOutKnot() {
-    const result = await post({action: "splice-out", id: knot.id});
+        if (result.error) {
+            error = result.error;
+            return false;
+        }
 
-    processResult(result);
-
-    if (result.error) {
-        alert(result.error)
+        return true;
     }
 
-    if( result.new_id) {
-        selectKnot(result.new_id);
+    async function spliceOutKnot() {
+        const result = await post({ action: "splice-out", id: knot.id });
+
+        processResult(result);
+
+        if (result.error) {
+            alert(result.error);
+        }
+
+        if (result.new_id) {
+            selectKnot(result.new_id);
+        }
     }
 
-}
+    async function onEditCommand(newCommand: string) {
+        return await completeEditProperty({
+            action: "edit-command",
+            id: knot.id,
+            command: newCommand,
+        });
+    }
 
-async function onEditCommand(newCommand: string) {
-   return  await completeEditProperty({ action: "edit-command", id: knot.id, command: newCommand});
- }
+    async function onInsertParent(newCommand: string) {
+        const result = await post({
+            action: "insert-parent",
+            id: knot.id,
+            command: newCommand,
+        });
 
- async function onInsertParent(newCommand: string) {
-    const result =   await post({ action: "insert-parent", id: knot.id, command: newCommand});
+        if (result.error) {
+            error = result.error;
+            return false;
+        }
 
-if (result.error) {
-    error = result.error;
-    return false;
-}
+        // This should recalculate the displayed knots to include the new parent
+        selectKnot(knot.id);
 
-    // This should recalculate the displayed knots to include the new parent
-    selectKnot(knot.id);
+        return true;
+    }
 
-return true;
- }
-
-
-const ddcolor = "hover:bg-slate-200";
-
+    const ddcolor = "hover:bg-slate-200";
 </script>
 
 <div class="border-x-4 {knotColor.border}" id="knot_{knot.id}">
     <KnotText response={knot.data.response} unblessed={knot.data.unblessed}>
         {#snippet actions()}
-        <div class="whitespace-normal flex flex-row absolute top-2 right-2 gap-x-2">
-            {#if knot.data.label}
-                <span class="text-bold bg-gray-200 border-1 p-1 rounded-md"
-                    >{knot.data.label}</span
-                >
-            {/if}
-            <Button
-                color="light"
-                size="xs"
-                class="w-0 {controlColor.background}"
-                ><DotsVerticalOutline class="w-4 h-4" />
-            </Button>
-            <Dropdown
-                placement="left"
-                bind:open={actionDropdownOpen}
-                class="w-96 bg-slate-100" >
-                <DropdownItem onclick={replay} class={ddcolor}
-                    >Replay
-                    <Helper>Run from start to here</Helper>
-                    </DropdownItem >
-                {#if knot.id != 0}
-                    <DropdownItem
-                        onclick={deleteKnot}
-                        class={ddcolor}>
-                        Delete
-                        <Helper>Delete this knot and all children</Helper>
-                    </DropdownItem>
-                    <DropdownItem
-                    onclick={spliceOutKnot}
-                    class={ddcolor}>
-                    Splice Out
-                    <Helper>Delete this knot, reparent childen up</Helper>
-                </DropdownItem>
-                {/if}
-                <DropdownItem
-                    onclick={bless}
-                    class="{blessClass} {ddcolor}">
-                    Bless
-                    <Helper>Accept changes</Helper>
-                </DropdownItem>
-                {#if knot.id != 0}
-                    <DropdownItem
-                        onclick={blessTo}
-                        class="{blessClass} {ddcolor}"
+            <div
+                class="whitespace-normal flex flex-row absolute top-2 right-2 gap-x-2"
+            >
+                {#if knot.data.label}
+                    <span class="text-bold bg-gray-200 border-1 p-1 rounded-md"
+                        >{knot.data.label}</span
                     >
-                        Bless To Here
-                        <Helper>Bless all knots from root to here</Helper>
-                    </DropdownItem>
-                    <DropdownItem
-                        onclick={() => activateField(editLabel)}
-                        class={ddcolor}>
-                        Edit Label
-                        <Helper>Change label for knot</Helper>
-                    </DropdownItem>
-                    <DropdownItem onclick={() => activateField(editCommand)} class={ddcolor}>
-                        Edit Command
-                        <Helper>Change the command</Helper>
-                    </DropdownItem>
                 {/if}
-                <DropdownItem onclick={newChild} class={ddcolor}>
-                    New Child
-                    <Helper>Add a new command after this</Helper>
-                </DropdownItem>
-                {#if knot.id != 0}
-                <DropdownItem onclick={() => activateField(insertParent)} class={ddcolor}>
-                    Insert Parent
-                    <Helper>Insert a command before this</Helper>
-                </DropdownItem>
-                {/if}
-            </Dropdown>
-            {#if knot.children.length > 0}
                 <Button
-                    class="w-0 {controlColor.background}"
                     color="light"
                     size="xs"
-                >
-                    <CodeMergeSolid class="w-4 h-4" />
+                    class="w-0 {controlColor.background}"
+                    ><DotsVerticalOutline class="w-4 h-4" />
                 </Button>
                 <Dropdown
                     placement="left"
-                    bind:open={childDropdownOpen}
-                    class="w-96 overflow-y-auto bg-slate-100"
+                    bind:open={actionDropdownOpen}
+                    class="w-96 bg-slate-100"
                 >
-                    {#each knot.children as child (child.id)}
-                        <DropdownItem
-                            onclick={() => setSelectedId(child.id)}
-                            class={category2color.get(child.treeCategory)
-                                .background}
-                        >
-                            {child.label}
+                    <DropdownItem onclick={replay} class={ddcolor}
+                        >Replay
+                        <Helper>Run from start to here</Helper>
+                    </DropdownItem>
+                    {#if knot.id != 0}
+                        <DropdownItem onclick={deleteKnot} class={ddcolor}>
+                            Delete
+                            <Helper>Delete this knot and all children</Helper>
                         </DropdownItem>
-                    {/each}
+                        <DropdownItem onclick={spliceOutKnot} class={ddcolor}>
+                            Splice Out
+                            <Helper
+                                >Delete this knot, reparent childen up</Helper
+                            >
+                        </DropdownItem>
+                    {/if}
+                    <DropdownItem
+                        onclick={bless}
+                        class="{blessClass} {ddcolor}"
+                    >
+                        Bless
+                        <Helper>Accept changes</Helper>
+                    </DropdownItem>
+                    {#if knot.id != 0}
+                        <DropdownItem
+                            onclick={blessTo}
+                            class="{blessClass} {ddcolor}"
+                        >
+                            Bless To Here
+                            <Helper>Bless all knots from root to here</Helper>
+                        </DropdownItem>
+                        <DropdownItem
+                            onclick={() => activateField(editLabel)}
+                            class={ddcolor}
+                        >
+                            Edit Label
+                            <Helper>Change label for knot</Helper>
+                        </DropdownItem>
+                        <DropdownItem
+                            onclick={() => activateField(editCommand)}
+                            class={ddcolor}
+                        >
+                            Edit Command
+                            <Helper>Change the command</Helper>
+                        </DropdownItem>
+                    {/if}
+                    <DropdownItem onclick={newChild} class={ddcolor}>
+                        New Child
+                        <Helper>Add a new command after this</Helper>
+                    </DropdownItem>
+                    {#if knot.id != 0}
+                        <DropdownItem
+                            onclick={() => activateField(insertParent)}
+                            class={ddcolor}
+                        >
+                            Insert Parent
+                            <Helper>Insert a command before this</Helper>
+                        </DropdownItem>
+                    {/if}
                 </Dropdown>
-            {/if}
-        </div>
+                {#if knot.children.length > 0}
+                    <Button
+                        class="w-0 {controlColor.background}"
+                        color="light"
+                        size="xs"
+                    >
+                        <CodeMergeSolid class="w-4 h-4" />
+                    </Button>
+                    <Dropdown
+                        placement="left"
+                        bind:open={childDropdownOpen}
+                        class="w-96 overflow-y-auto bg-slate-100"
+                    >
+                        {#each knot.children as child (child.id)}
+                            <DropdownItem
+                                onclick={() => setSelectedId(child.id)}
+                                class={category2color[child.treeCategory].background}
+                            >
+                                {child.label}
+                            </DropdownItem>
+                        {/each}
+                    </Dropdown>
+                {/if}
+            </div>
         {/snippet}
     </KnotText>
     <hr />
@@ -242,19 +258,19 @@ const ddcolor = "hover:bg-slate-200";
 />
 
 <EditProperty
-title="Edit Command"
-change={onEditCommand}
-value={knot.data.command}
-error={error}
-bind:this={editCommand}
-help="After renaming, the Skein will replay to this knot"> 
-</EditProperty>
+    title="Edit Command"
+    change={onEditCommand}
+    value={knot.data.command}
+    {error}
+    bind:this={editCommand}
+    help="After renaming, the Skein will replay to this knot"
+></EditProperty>
 
 <EditProperty
-title="Insert Parent"
-change={onInsertParent}
-value="z"
-error={error}
-bind:this={insertParent}
-help="New command will be inserted between this command and its parent"> 
-</EditProperty>
+    title="Insert Parent"
+    change={onInsertParent}
+    value="z"
+    {error}
+    bind:this={insertParent}
+    help="New command will be inserted between this command and its parent"
+></EditProperty>

--- a/skein-ui/src/lib/KnotText.svelte
+++ b/skein-ui/src/lib/KnotText.svelte
@@ -5,7 +5,7 @@
     interface Props {
         response : string, 
         unblessed : string | undefined,
-        actions : Snippet
+        actions : Snippet | null
     }
 
 

--- a/skein-ui/src/lib/NewCommand.svelte
+++ b/skein-ui/src/lib/NewCommand.svelte
@@ -25,7 +25,7 @@
         // TODO: Typescripty way to ensure is HTMLElement
         if (element as HTMLElement) {
             element.focus();
-            element.scrollIntoView({ behavior: "smooth", block: "center" });
+            element.scrollIntoView({ behavior: "smooth", block: "end" });
         }
     }
 

--- a/skein-ui/src/lib/common.svelte.ts
+++ b/skein-ui/src/lib/common.svelte.ts
@@ -14,8 +14,8 @@ export type Payload = {
 export type ActionResult = {
     updates: KnotData[],
     removed_ids: number[],
-    // knot id to select (scroll to)
-    selected: number | null,
+    // knot id to focus on (e.g., scroll to)
+    focus: number,
     enable_undo: boolean,
     enable_redo: boolean,
     // Only for new-command:

--- a/skein-ui/src/lib/common.svelte.ts
+++ b/skein-ui/src/lib/common.svelte.ts
@@ -1,4 +1,4 @@
-import { type KnotData, Category } from "./types";
+import { type KnotData, type Category } from "./types";
 
 const url = "//localhost:10140/api";
 
@@ -14,6 +14,8 @@ export type Payload = {
 export type ActionResult = {
     updates: KnotData[],
     removed_ids: number[],
+    // knot id to select (scroll to)
+    selected: number | null,
     enable_undo: boolean,
     enable_redo: boolean,
     // Only for new-command:
@@ -43,22 +45,14 @@ export async function postApi(payload: Payload): Promise<ActionResult> {
     return await response.json();
 }
 
-export function category(knot: KnotData): Category {
-    if (knot.unblessed == undefined) { return Category.OK; }
-
-    if (knot.response == undefined) { return Category.NEW; }
-
-    return Category.ERROR
-}
-
 export function mergeCategory(left: Category, right: Category): Category {
     // TODO: all this is really the max of the two inputs
 
-    if (left == Category.ERROR || right == Category.ERROR) { return Category.ERROR; }
+    if (left == "error" || right == "error") { return "error"; }
 
-    if (left == Category.NEW || right == Category.NEW) { return Category.NEW; }
+    if (left == "new" || right == "new") { return "new"; }
 
-    return Category.OK;
+    return "ok";
 }
 
 

--- a/skein-ui/src/lib/derived.svelte.ts
+++ b/skein-ui/src/lib/derived.svelte.ts
@@ -1,7 +1,7 @@
-import { type KnotData, Category } from "./types";
-import { category, mergeCategory } from "./common.svelte";
+import { type KnotData, type Category } from "./types";
+import { mergeCategory } from "./common.svelte";
 
-export function deriveKnotCategory(knots: Map<number, KnotData>) {
+export function deriveId2TreeCategory(knots: Map<number, KnotData>) {
     let result = new Map<number, Category>();
 
     // ids of knots whose own category is not OK; used
@@ -9,9 +9,9 @@ export function deriveKnotCategory(knots: Map<number, KnotData>) {
     let failedIds = Array<number>();
 
     for (const [id, knot] of knots) {
-        const c = category(knot);
+        const c = knot.category;
 
-        if (c != Category.OK) {
+        if (c != "ok") {
             result.set(id, c);
             failedIds.push(id);
         }
@@ -21,16 +21,16 @@ export function deriveKnotCategory(knots: Map<number, KnotData>) {
     // Lots of redundant work here, but efficiency is not necessary.
 
     for (const failedId of failedIds) {
-        let c = result.get(failedId) || Category.OK;
+        let c = result.get(failedId) || "ok";
 
-        if (c != Category.OK) {
+        if (c != "ok") {
             let id = failedId;
             while (true) {
                 const parentId = knots.get(id)?.parent_id;
 
                 if (parentId == undefined) { break; }
 
-                c = mergeCategory(c, result.get(parentId) || Category.OK);
+                c = mergeCategory(c, result.get(parentId) ||"ok");
 
                 result.set(parentId, c);
 
@@ -44,7 +44,7 @@ export function deriveKnotCategory(knots: Map<number, KnotData>) {
 
 
 // derives the list of of knots ids to display, starting with 0, and working forward from each node's selected child id.
-export function deriveDisplayIds(knots: Map<number, KnotData>, selected: Map<number, number>) {
+export function deriveDisplayIds(knots: Map<number, KnotData>,) {
     let nodeIds = Array<number>();
     let id = 0;
 
@@ -55,39 +55,33 @@ export function deriveDisplayIds(knots: Map<number, KnotData>, selected: Map<num
 
         nodeIds.push(id);
 
-        id = selected.get(id) || -1;
+        id = knot.selected || -1;
     }
 
     return nodeIds;
 };
 
 // Using knots map, derived total number of knots
-export function deriveKnotTotals(knots: Map<number, KnotData>): Map<Category, number> {
+export function deriveKnotTotals(knots: Map<number, KnotData>): Record<Category, number> {
 
-    let result = new Map<Category, number>();
-    result.set(Category.OK, 0);
-    result.set(Category.NEW,  0);
-    result.set(Category.ERROR, 0);
+    let result = { ok: 0, new: 0, error: 0 }
 
     for (const [_, knot] of knots) {
-
-        const c = category(knot);
-        
-        result.set(c, result.get(c) + 1);
+        result[knot.category] += 1
     }
-    
+
     return result;
 }
 
-type LabelTuple = {
+type KnotLabel = {
     label: string,
     id: number
 }
 
-// Using knots map, derives a list of label tuples [String, long]
+// Using knots map, derives a list of KnotLabels
 // in sorted order.
-export function deriveLabels(knots: Map<number, KnotData>): LabelTuple[] {
-    let result = new Array<LabelTuple>();
+export function deriveLabels(knots: Map<number, KnotData>): KnotLabel[] {
+    let result = new Array<KnotLabel>();
 
     for (const [id, knot] of knots) {
         if (knot.label) {

--- a/skein-ui/src/lib/derived.svelte.ts
+++ b/skein-ui/src/lib/derived.svelte.ts
@@ -44,7 +44,8 @@ export function deriveId2TreeCategory(knots: Map<number, KnotData>) {
 
 
 // derives the list of of knots ids to display, starting with 0, and working forward from each node's selected child id.
-export function deriveDisplayIds(knots: Map<number, KnotData>,) {
+export function deriveDisplayIds(knots: Map<number, KnotData>) {
+    
     let nodeIds = Array<number>();
     let id = 0;
 

--- a/skein-ui/src/lib/knot-color.ts
+++ b/skein-ui/src/lib/knot-color.ts
@@ -1,16 +1,17 @@
 import { Category } from "./types";
 
-export const category2color = new Map<Category, { border: string, background: string }>();
+type Category2Color =  Record<Category, { border: string, background: string }>;
 
-category2color.set(Category.ERROR, {
-    border: "border-rose-400",
-    background: "bg-rose-200 hover:bg-rose-400",
-});
+export const category2color : Category2Color = {
+    ok: { border: "border-slate-100", background: "hover:bg-slate-200" },
+    new: {
+        border: "border-yellow-200",
+        background: "bg-yellow-200 hover:bg-yellow-300",
+    },
+    error: {
+        border: "border-rose-400",
+        background: "bg-rose-200 hover:bg-rose-400",
+    }
+};
 
-category2color.set(Category.NEW, {
-    border: "border-yellow-200",
-    background: "bg-yellow-200 hover:bg-yellow-300",
-});
-
-category2color.set(Category.OK, { border: "border-slate-100", background: "hover:bg-slate-200" });
 

--- a/skein-ui/src/lib/types.ts
+++ b/skein-ui/src/lib/types.ts
@@ -3,6 +3,9 @@
 export type KnotData = {
     id: number,
     parent_id: number | null,
+    // Category is derived from response and unblessed
+    category: Category,
+    selected: number | null,
     label?: string,
     command: string,
     // When a command is first added, response is undefined, and unblessed is a string
@@ -12,11 +15,7 @@ export type KnotData = {
     children: number[];
 }
 
-// OK: response, no unblessed
-// NEW: unblessed, no response
-// ERROR: both response and unblessed, and they are not equal
-
-export enum Category { OK, NEW, ERROR }
+export type Category = "ok" | "new" | "error";
 
 export interface KnotChild {
     id: number,
@@ -27,11 +26,7 @@ export interface KnotChild {
 export interface KnotNode  {
     id: number,
     data: KnotData,
-    // Category for self:
-    category: Category,
     // Category inherited up from children:
     treeCategory: Category,
-    // Id this still needed?
-    selectedChildId: number | null,
     children: KnotChild[]
 }

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -49,11 +49,11 @@
 
 (defcommand skein
   "Runs the Skein UI to test the Dialog project."
-  [seed [nil "--seed NUMBER" "Random number generator seed to use, if creating a new skein."
+  [seed [nil "--seed NUMBER" "Random number generator seed to use, if creating a new skein"
          :parse-fn parse-long
          :validate [some? "Not a number"
                     pos-int? "Must be at least one"]]
-   skein ["-f" "--file SKEIN" "Path to file containing the Skein; will be created if necessary."
+   skein ["-f" "--file SKEIN" "Path to file containing the Skein; will be created if necessary"
           :default "default.skein"]]
   (let [project (pf/read-project)
         {:keys [port]} (service/start! project skein (cond-> nil
@@ -98,7 +98,7 @@
 
 (defn- run-tests
   [project width skein-path]
-  (let [tree      (sk.file/load-skein skein-path)
+  (let [tree (sk.file/load-skein skein-path)
         process   (sk.process/start-debug-process! project (get-in tree [:meta :seed]))
         session   (-> (s/create-loaded! process skein-path tree)
                       (s/enable-undo false))

--- a/src/dialog_tool/skein/file.clj
+++ b/src/dialog_tool/skein/file.clj
@@ -27,7 +27,7 @@
 (defn- unblessed-sep?
   [s]
   (and (some? s)
-       (re-matches #"<+{4,}" s)))
+       (re-matches #"<{4,}" s)))
 
 (defn- s->long
   [s]
@@ -39,6 +39,9 @@
   (let [{:keys [meta knots]} tree]
     (p out "seed" (:seed meta))
     (doseq [knot-id (-> tree :knots keys sort)
+            ;; Purposely don't write the :selected property as that is only meaningful
+            ;; during editing and would cause many unwanted changes to the skein stored in
+            ;; version control.  We want skein changes to be reviewable.
             :let [{:keys [id parent-id response unblessed command label]} (get knots knot-id)]]
       (.println out sep)
       (p out "id" id)

--- a/src/dialog_tool/skein/handlers.clj
+++ b/src/dialog_tool/skein/handlers.clj
@@ -33,7 +33,7 @@
     ;; sending just what's changed.
     {:updates     (mapv tree/knot->wire updates)
      :removed_ids removed-ids
-     :selected    (:selected new-tree)}))
+     :focus       (:focus new-tree)}))
 
 (defn- bless
   [session payload]
@@ -42,10 +42,6 @@
 (defn- bless-to
   [session payload]
   (session/bless-to session (:id payload)))
-
-(defn- bless-all
-  [session _payload]
-  (session/bless-all session))
 
 (defn- prep-command
   [s]
@@ -113,6 +109,7 @@
   (session/label session id (string/trim label)))
 
 (defn- select
+  "Selects a knot (ensures it is visible); it may bring in its selected child as well; will be focused."
   [session {:keys [id]}]
   (session/select-knot session id))
 
@@ -163,7 +160,6 @@
 
 (def action->handler
   {"bless"         bless
-   "bless-all"     bless-all
    "bless-to"      bless-to
    "label"         label
    "new-command"   new-command

--- a/src/dialog_tool/skein/handlers.clj
+++ b/src/dialog_tool/skein/handlers.clj
@@ -32,7 +32,8 @@
     ;; Because we don't care about efficiency, we send the entire updated knot, rather than
     ;; sending just what's changed.
     {:updates     (mapv tree/knot->wire updates)
-     :removed_ids removed-ids}))
+     :removed_ids removed-ids
+     :selected    (:selected new-tree)}))
 
 (defn- bless
   [session payload]
@@ -111,6 +112,10 @@
   [session {:keys [id label]}]
   (session/label session id (string/trim label)))
 
+(defn- select
+  [session {:keys [id]}]
+  (session/select-knot session id))
+
 (defn- start-batch
   "Turns off undo tracking, so the session will start to accumulate changes
   from all the following commands, until end-batch, which renables undo
@@ -167,7 +172,8 @@
    "undo"         undo
    "redo"         redo
    "delete"       delete
-   "splice-out" splice-out})
+   "splice-out" splice-out
+   "select" select})
 
 (defn- update-handler
   [request]

--- a/src/dialog_tool/skein/handlers.clj
+++ b/src/dialog_tool/skein/handlers.clj
@@ -116,6 +116,10 @@
   [session {:keys [id]}]
   (session/select-knot session id))
 
+(defn- deselect
+  [session {:keys [id]}]
+  (session/deselect session id))
+
 (defn- start-batch
   "Turns off undo tracking, so the session will start to accumulate changes
   from all the following commands, until end-batch, which renables undo
@@ -158,22 +162,23 @@
      :body   body}))
 
 (def action->handler
-  {"bless"        bless
-   "bless-all"    bless-all
-   "bless-to"     bless-to
-   "label"        label
-   "new-command"  new-command
-   "edit-command" edit-command
+  {"bless"         bless
+   "bless-all"     bless-all
+   "bless-to"      bless-to
+   "label"         label
+   "new-command"   new-command
+   "edit-command"  edit-command
    "insert-parent" insert-parent
-   "start-batch"  start-batch
-   "end-batch"    end-batch
-   "save"         save
-   "replay"       replay
-   "undo"         undo
-   "redo"         redo
-   "delete"       delete
-   "splice-out" splice-out
-   "select" select})
+   "start-batch"   start-batch
+   "end-batch"     end-batch
+   "save"          save
+   "replay"        replay
+   "undo"          undo
+   "redo"          redo
+   "delete"        delete
+   "splice-out"    splice-out
+   "select"        select
+   "deselect"      deselect})
 
 (defn- update-handler
   [request]

--- a/src/dialog_tool/skein/service.clj
+++ b/src/dialog_tool/skein/service.clj
@@ -43,7 +43,7 @@
                  (rand-int 10000))
         process (sk.process/start-debug-process! project seed)
         session (if tree
-                  (s/create-loaded! process skein-path tree)
+                  (s/create-loaded! process skein-path (tree/apply-default-selections tree))
                   (s/create-new! process skein-path))
         shutdown-fn (hk/run-server service-handler-proxy
                                    {:port          port
@@ -78,6 +78,7 @@
   (start! (pf/read-project "../sanddancer-dialog")
           "../sanddancer-dialog/default.skein"
           nil)
+
 
   (@*shutdown)
 

--- a/src/dialog_tool/skein/session.clj
+++ b/src/dialog_tool/skein/session.clj
@@ -171,19 +171,9 @@
 (defn select-knot
   [session knot-id]
   (-> session
-      (update :tree tree/select-knot knot-id)
-      (assoc-in [:tree :selected] knot-id)))
-
-;; TODO: Not used in the UI, should be removed.
-
-(defn bless-all
-  [session]
-  (let [session' (capture-undo session)
-        ids (-> session' :tree tree/all-knots (map :id))]
-    (assoc session :tree (reduce (fn [tree knot-id]
-                                   (tree/bless-response tree knot-id))
-                                 (:tree session')
-                                 ids))))
+      capture-undo
+      (cond-> (not= knot-id 0) (update :tree tree/select-knot knot-id))
+      (assoc-in [:tree :focus] knot-id)))
 
 (defn save!
   "Saves the current tree state to the file.  Does not affect undo/redo."

--- a/src/dialog_tool/skein/session.clj
+++ b/src/dialog_tool/skein/session.clj
@@ -168,6 +168,12 @@
         capture-undo
         (assoc :tree (reduce tree/bless-response tree ids)))))
 
+(defn select-knot
+  [session knot-id]
+  (-> session
+      (update :tree tree/select-knot knot-id)
+      (assoc-in [:tree :selected] knot-id)))
+
 ;; TODO: Not used in the UI, should be removed.
 
 (defn bless-all

--- a/src/dialog_tool/skein/session.clj
+++ b/src/dialog_tool/skein/session.clj
@@ -260,3 +260,9 @@
   "Kills the session, and the underlying process. Returns nil."
   [session]
   (sk.process/kill! (:process session)))
+
+(defn deselect
+  [session id]
+  (-> session
+      capture-undo
+      (update :tree tree/deselect id)))

--- a/src/dialog_tool/skein/tree.clj
+++ b/src/dialog_tool/skein/tree.clj
@@ -218,3 +218,9 @@
   [tree knot-id]
   (let [{:keys [parent-id]} (get-knot tree knot-id)]
     (assoc-in tree [:knots parent-id :selected] knot-id)))
+
+(defn deselect
+  [tree knot-id]
+  (-> tree
+      (assoc-in [:knots knot-id :selected] nil)
+      (assoc :selected knot-id)))


### PR DESCRIPTION
The selected knot is now computed on the server, and is part of the undo/redo stack. This moves more logic to the server, behaves more predictably, is cleaner to implement, and runs more efficiently.