### PR TITLE
Support running the skein using dfrotz instead of dgdebug

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Creating magnum-opus ...
   
 Change to directory magnum-opus to begin work
 dgt debug to run the project in the Dialog debugger
-dgt skein to open a web browser to the Skein UI
+dgt new-skein to open a web browser to the Skein UI
 dgt help for other options
 ```
 
@@ -157,8 +157,9 @@ as status bar updates; to verify these, you must run using Frotz.
 
 ## Running the Skein
 
-`dgt skein` will open up the skein UI.  By default, the file is named `default.skein`, or you can provide a different
-name (you may want to have multiple skein files).  The file will be created as needed.
+`dgt new-skein` will open up the skein UI for a new skein file.  
+By default, the file is named `default.skein`, or you can provide a different
+name, as you may want to have multiple skein files. 
 
 The Skein UI is an alternate way of running your project in the Dialog debugger; you interact through
 a web-based user interface.
@@ -167,6 +168,8 @@ The Skein represents your project as a tree of "knots"; each knot is a command. 
 add new commands beneath any knot, and you can also rerun the project to any knot
 and the skein will identify any text that has changed.  You can even run *all* possible branches
 to completion.
+
+`dgt skein` will open an existing skein.
 
 > More on this later
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ A minimal example `dialog.edn` (as created by `dgt new`):
  {:zblorb
   {:options ["--cover-alt" "Magnum-opus"]}}
  :sources
- {:story   ["src/*.dg"]
+ {:main    ["src/*.dg"]
   :debug   ["lib/dialog/stddebug.dg"]
   :library ["lib/dialog/stdlib.dg"]}}
 ```                   
@@ -99,10 +99,16 @@ For each, you may specify any number of individual files, or _glob matches_.
 You should be careful with glob matches, as Dialog can be sensitive to the order in which
 source files are loaded.
 
-* `:story` - sources specific to your project
-* `:debug` - used by the commands `test`, `debug`, `skein`, etc.
-* `:library` - additional libraries, including the Dialog standard library
+* :main - sources specific to your project
+* :debug - used by the commands `test`, `debug`, `skein`, etc.
+* :library - additional libraries, including the Dialog standard library
 
+Generally, source that is specific to your project goes in :main; reusable code goes in :library and :debug; 
+this may include code obtained from others, including the standard library.
+
+It is a common practice to modify libraries as necessary, even the standard library!  Another
+good practice is to try and split out reusable code (code that could reasonably be used in an entirely different
+project) under :library (and :debug).
 
 ### Format
 
@@ -110,13 +116,12 @@ The :format key defines the output when the project is built; :zblorb is a good 
 In specific situations you may want to build for :z5, :z8, or :aa.  The differences between
 these formats are described in [the Dialog manual](https://linusakesson.net/dialog/docs/software.html#compiler).
 
-
 ### Build Config
 
-The :build key contains build configuration for each format (when publishing for the web, you may build once for the 
-project, and a second time in :aa format for the web).
+The :build key contains build configuration for each format. When bundling, you may build once according
+to the project's format, and a second time in :aa format for the web.
 
-The :options key is used to specify additional options to add to the command line.
+The :options key is used to specify additional options to add to the `dialogc` command line.
 This is typically used to set the heap size information.
 
 Under :build, the :default key contains defaults for building (any format); the specific build map (:zblorb, in our example)
@@ -124,7 +129,7 @@ is merged on top of the :default map, if present.
 
 ## Running your project
 
-`dgt debug` will start your project in the debugger so you can play interactively at the console.
+`dgt debug` will start your project in the `dgdebug` so you can explore your creation interactively at the console.
 
 ```
 > dgt debug
@@ -210,8 +215,12 @@ Building out/release/magnum-opus.aastory ...
   out/web/cover.png
   out/web/cover-small.jpg
   out/web/index.html
+  out/magnum-opus-0.zip
 ```
-Bundle creates a directory and populates it with a custom page for your project; if you open `out/web/index.html` in a web browser, you'll be provided with an option to download the game file, or play the game in-browser:
+The `bundle` command creates a directory and populates it with a custom page for your project.
+It also creates a `.zip` file of the contents of `out/web` (the name is based on the project's name, and the version number inside `src/meta.dg`)
+
+If you open `out/web/index.html` in a web browser, you'll be provided with an option to download the game file, or play the game in-browser:
 
 ![Bundled Web Page](images/web-bundle-loaded.png)
 

--- a/resources/dfrotz-skein-patch.dg
+++ b/resources/dfrotz-skein-patch.dg
@@ -1,0 +1,4 @@
+%% Include this file first when building for dfrotz and the skein
+
+(redraw status bar)
+    %% Do nothing; otherwise the status bar is output inline in transcript

--- a/resources/template/dialog.edn
+++ b/resources/template/dialog.edn
@@ -4,6 +4,6 @@
  {:zblorb
   {:options ["--cover-alt" "{{project-name|capitalize}}"]}}
  :sources
- {:story   ["src/*.dg"]
+ {:main   ["src/*.dg"]
   :debug   ["lib/dialog/stddebug.dg"]
   :library ["lib/dialog/stdlib.dg"]}}

--- a/src/dialog_tool/build.clj
+++ b/src/dialog_tool/build.clj
@@ -55,11 +55,11 @@
 (defn build-project
   "Builds a project; returns the path of the compiled file."
   [project options]
-  (let [{:keys [format debug?]} options
+  (let [{:keys [format debug? ]} options
         format     (or format (:format project))
+        _     (when-not format
+                (fail "No :format defined for project"))
         output-dir (fs/path "out" (if debug? "test" "release"))
-        sources    (pf/expand-sources project {:debug? debug?})]
-    (when-not format
-      (fail "No :format defined for project"))
+        sources    (pf/expand-sources project options)]
     (fs/create-dirs output-dir)
     (invoke-dialogc format project sources output-dir options)))

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -197,7 +197,7 @@
                                    :debug? debug?})
         command (if dumb? "dfrotz" "frotz")
         extra-args (when dumb?
-                     ["-m"])
+                     ["-m" "-q"])
         args (concat extra-args
                      frotz-args
                      [(str path)])]

--- a/src/dialog_tool/project_file.clj
+++ b/src/dialog_tool/project_file.clj
@@ -2,7 +2,8 @@
   (:require [clojure.edn :as edn]
             [babashka.fs :as fs]
             [dialog-tool.util :refer [fail]]
-            [clojure.string :as string]))
+            [clojure.string :as string])
+  (:import (java.nio.file Path)))
 
 (defn read-project
   ;; 0 arity is normal, 1 arity is just for testing purposes
@@ -25,19 +26,26 @@
 
 (defn- expand-source
   [dir glob]
-  (if (string/starts-with? glob "/")
+  (cond
+    (instance? Path glob)
+    [(str glob)]
+
+    (string/starts-with? glob "/")
     [glob]
+
+    :else
     (fs/glob dir glob)))
 
 (defn expand-sources
   ([project]
    (expand-sources project nil))
-  ([project {:keys [debug?]}]
+  ([project {:keys [debug? pre-patch]}]
    (let [{::keys [dir]
           :keys  [sources]} project
-         {:keys [story debug library]} sources
+         {:keys [main debug library]} sources
          globs (concat
-                 story
+                 pre-patch
+                 main
                  (when debug? debug)
                  library)]
      (->> globs

--- a/src/dialog_tool/project_file.clj
+++ b/src/dialog_tool/project_file.clj
@@ -13,11 +13,15 @@
          path (fs/path dir '"dialog.edn")]
      (or (fs/exists? path)
          (fail (str path) " does not exist"))
-     (-> path
-         fs/file
-         slurp
-         edn/read-string
-         (assoc ::dir dir')))))
+     (try
+       (-> path
+           fs/file
+           slurp
+           edn/read-string
+           (assoc ::dir dir'))
+       (catch Throwable t
+         (fail "Could not read " [:bold path] ": "
+               (ex-message t)))))))
 
 (defn- expand-source
   [dir glob]
@@ -39,6 +43,10 @@
      (->> globs
           (mapcat #(expand-source dir %))
           (map str)))))
+
+(defn project-dir
+  [project]
+  (::dir project))
 
 
 

--- a/src/dialog_tool/skein/file.clj
+++ b/src/dialog_tool/skein/file.clj
@@ -38,6 +38,7 @@
   [tree ^PrintWriter out]
   (let [{:keys [meta knots]} tree]
     (p out "seed" (:seed meta))
+    (p out "engine" (:engine meta))
     (doseq [knot-id (-> tree :knots keys sort)
             ;; Purposely don't write the :selected property as that is only meaningful
             ;; during editing and would cause many unwanted changes to the skein stored in
@@ -57,7 +58,8 @@
 
 
 (def meta-parsers
-  {"seed" s->long})
+  {"seed" s->long
+   "engine" keyword})
 
 (def kv-re #"(?x)
     (.+):   # key portion

--- a/src/dialog_tool/skein/process.clj
+++ b/src/dialog_tool/skein/process.clj
@@ -3,6 +3,7 @@
   sending it commands to execute, and receiving back
   the results (output) from those commands."
   (:require [babashka.fs :as fs]
+            [babashka.process :as p]
             [clojure.core.async :refer [chan close! >!! <!!]]
             [clojure.string :as string]
             [dialog-tool.project-file :as pf])
@@ -41,21 +42,24 @@
 (defn- start-thread
   [reader output-ch]
   (let [f #(read-loop reader output-ch)]
-    (doto (Thread. ^Runnable f "dialog debugger reader")
+    (doto (Thread. ^Runnable f "skein process output reader")
       (.setDaemon true)
       .start)))
 
 (defn- start!
-  [dir ^List cmd seed]
-  (let [process (-> (ProcessBuilder. cmd)
-                    (.directory dir)
+  [^List cmd opts]
+  (let [{:keys [pre-flight]} opts
+        ;; pre-flight is optional, used to build the .zblorb file for example,
+        ;; so it must be before starting the process.
+        _ (when pre-flight
+            (pre-flight))
+        process (-> (ProcessBuilder. cmd)
                     .start)
         stdout-reader (.inputReader process)
         output-ch (chan)]
     {:process      process
-     :seed         seed
-     :dir          dir
      :cmd          cmd
+     :opts         opts
      :stdin-writer (-> process .outputWriter PrintWriter.)  ; write stdin of process
      :output-ch    output-ch
      :thread       (start-thread stdout-reader output-ch)}))
@@ -63,39 +67,83 @@
 (defn start-debug-process!
   "Starts a Skein process using the Dialog debugger."
   [project seed]
-  (let [^List cmd (-> ["dgdebug"
-                       "--quit"
-                       "--seed" (str seed)
-                       "--width" "80"]
-                      (into (pf/expand-sources project {:debug? true})))
-        dir (-> project :dir fs/file)]
-    (start! dir cmd seed)))
+  (let [cmd (-> ["dgdebug"
+                 "--quit"
+                 "--seed" (str seed)
+                 "--width" "80"]
+                (into (pf/expand-sources project {:debug? true})))]
+    (start! cmd nil)))
+
+
+(def engines #{:dgdebug :frotz})
+
+(defmulti start-process! (fn [_project engine _seed] engine))
+
+(defmethod start-process! :dgdebug
+  [project _ seed]
+  (start-debug-process! project seed))
+
+(defmethod start-process! :frotz
+  [project _ seed]
+  (let [{project-name :name} project
+        project-dir (pf/project-dir project)
+        output-dir (fs/path project-dir "out" "skein")
+        path (fs/path output-dir (str project-name ".zblorb"))
+        pre (fn []
+              (p/check
+                (p/sh (into ["dialogc"
+                             "--format" "zblorb"
+                             "--output" (str path)]
+                            (pf/expand-sources project {:debug? true})))))
+        cmd ["dfrotz"
+             ;; Flags: quiet, no *more*
+             "-q" "-m"
+             "-s" (str seed)
+             "-w" "80"
+             (str path)]]
+    (fs/create-dirs output-dir)
+    (start! cmd {:pre-flight   pre
+                 :echo-command true})))
 
 (defn read-response!
-  [debug-process]
-  (-> debug-process :output-ch <!!))
+  [process]
+  (-> process :output-ch <!!))
+
+(defn- inject-command
+  [command response]
+  (let [x (string/index-of response "\n")]
+    (str
+      (subs response 0 x)
+      command
+      (subs response (inc x)))))
 
 (defn send-command!
   "Sends a player command to the process, blocking until a response to the command
   is available.  Returns the response."
-  [debug-process ^String cmd]
-  (let [{:keys [^PrintWriter stdin-writer]} debug-process]
-    (doto stdin-writer
-      (.print cmd)
-      .println
-      .flush))
-  (read-response! debug-process))
+  [process ^String command]
+  (let [{:keys [^PrintWriter stdin-writer opts]} process
+        {:keys [echo-command]} opts
+        _ (doto stdin-writer
+            (.print command)
+            .println
+            .flush)
+        raw-response (read-response! process)]
+    ;; dgdebug echos back what it receives on its stdin, but dfrotz does not.
+    ;; The echo-command flag lets us fake it.
+    (if echo-command
+      (inject-command command raw-response)
+      raw-response)))
 
 (defn kill!
-  "Kills the debug process and returns nil."
-  [debug-process]
-  (let [{:keys [^Process process]} debug-process]
+  "Kills the process and returns nil."
+  [process]
+  (let [{:keys [^Process process]} process]
     (.destroy process))
   nil)
 
 (defn restart!
-  "Kills the debug process and starts a new one, returning a new process map."
-  [debug-process]
-  (kill! debug-process)
-  (let [{:keys [dir cmd seed]} debug-process]
-    (start! dir cmd seed)))
+  "Kills the process and starts a new one, returning a new process map."
+  [process]
+  (kill! process)
+  (let [{:keys [cmd opts]} process]
+    (start! cmd opts)))

--- a/src/dialog_tool/skein/session.clj
+++ b/src/dialog_tool/skein/session.clj
@@ -19,14 +19,14 @@
      :redo-stack     []
      :process        process
      :tree           (tree/update-response tree 0 initial-response)
-     :undo-enabled? true
+     :undo-enabled?  true
      :active-knot-id 0}))
 
 (defn create-new!
-  "Creates a new session from an existing debug process.  The process should be
-  just started, so that we can read the initial response."
-  [process skein-path]
-  (create-loaded! process skein-path (tree/new-tree (:seed process))))
+  "Creates a new session for a new skein, using an existing process.  The process should be
+  just started, so that we can read the initial response. Creates a new tree for the session."
+  [process skein-path engine seed]
+  (create-loaded! process skein-path (tree/new-tree engine seed)))
 
 (defn enable-undo
   [session undo-enabled?]

--- a/src/dialog_tool/skein/tree.clj
+++ b/src/dialog_tool/skein/tree.clj
@@ -7,8 +7,9 @@
             [medley.core :as medley]))
 
 (defn new-tree
-  [seed]
-  {:meta  {:seed seed}
+  [engine seed]
+  {:meta  {:engine engine
+           :seed seed}
    :focus 0                                                 ; knot id to focus on
    :knots {0 {:id    0
               :label "START"}}})

--- a/src/dialog_tool/template.clj
+++ b/src/dialog_tool/template.clj
@@ -104,6 +104,6 @@
 
     (perr "\nChange to directory " [:bold dir] " to begin work")
     (perr [:bold "dgt debug"] " to run the project in the Dialog debugger")
-    (perr [:bold "dgt skein"] " to open a web browser to the Skein UI")
+    (perr [:bold "dgt new-skein"] " to open a web browser to the Skein UI")
     (perr [:bold "dgt help"] " for other options")))
 

--- a/src/dialog_tool/util.clj
+++ b/src/dialog_tool/util.clj
@@ -1,5 +1,6 @@
 (ns dialog-tool.util
-  (:require [clj-commons.ansi :refer [perr]]
+  (:require [babashka.fs :as fs]
+            [clj-commons.ansi :refer [perr]]
             [net.lewisship.cli-tools :as cli]))
 
 (defn fail
@@ -8,4 +9,14 @@
          [:bold "ERROR: "]
          msg])
   (cli/exit -1))
+
+(defn root-path
+  "Construct a Path from the root folder of the dialog tool (the directory containing
+  the dgt script) to a file."
+  [& terms]
+  (let [root
+        (-> *file*
+            fs/path
+            fs/parent)]
+    (apply fs/path root terms)))
 


### PR DESCRIPTION
This will not be stable until the next release of dfrotz, see https://gitlab.com/DavidGriffith/frotz/-/issues/290.

The :story key (inside :sources) was renamed to :main.

The `skein` command is now `new-skein` to create a new skein (optionally specifying seed and engine) and `skein` to run an existing skein.

