### PR TITLE
Specify only the directories for sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ A minimal example `dialog.edn` (as created by `dgt new`):
   {:options ["--cover"     "cover.png" 
              "--cover-alt" "Magnum-opus"]}}
  :sources
- {:main    ["src/*.dg"]
-  :debug   ["lib/dialog/stddebug.dg"]
-  :library ["lib/dialog/stdlib.dg"]}}
+ {:main    ["src"]
+  :debug   ["lib/dialog/debug"]
+  :library ["lib/dialog"]}}
 ```                   
 
 ### Source Paths
@@ -95,16 +95,15 @@ and _in what order_ they should apply (which is very critical to how Dialog oper
 Further, during development and testing you will often include extra "debug" sources that should not 
 be included when building and packaging your project for release.
 
-`dgt` uses three sets of sources.
-For each, you may specify any number of individual files, or _glob matches_.
-You should be careful with glob matches, as Dialog can be sensitive to the order in which
-source files are loaded.
+`dgt` uses three sets of sources.  For each set, you may specify a number of directories, relative
+to your project, in which to locate source files. All Dialog source files _directly_ in each directory
+are included.
 
 * :main - sources specific to your project
 * :debug - used by the commands `test`, `debug`, `skein`, etc.
 * :library - additional libraries, including the Dialog standard library
 
-Generally, source that is specific to your project goes in :main; reusable code goes in :library and :debug; 
+Generally, source code that is specific to your project goes in :main; reusable code goes in :library and :debug; 
 this may include code obtained from others, including the standard library.
 
 It is a common practice to modify libraries as necessary, even the standard library!  Another
@@ -156,7 +155,9 @@ your imagination.
 
 However, you are likely to spend very little time directly running the debugger; instead, you'll run the debugger indirectly, via the Skein.
 
-You can also run your project using [frotz](https://gitlab.com/DavidGriffith/frotz) with `dgt run`.  This will compile your project first.
+You can also run your project using [frotz](https://gitlab.com/DavidGriffith/frotz) with `dgt run`.  
+This will compile your project first.
+By default, debug sources are excluded, but you can run with the `--debug` switch to include them as well.
 
 Neither the debugger nor the Skein can present all the possible Dialog screen effects, such
 as status bar updates; to verify these, you must run using Frotz.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Creating magnum-opus ...
   src/meta.dg
   src/magnum-opus.dg
   lib/dialog/stdlib.dg
-  lib/dialog/stddebug.dg
+  lib/dialog/debug/stddebug.dg
   cover.png
   bundle/index.html
   bundle/play.css

--- a/resources/template/dialog.edn
+++ b/resources/template/dialog.edn
@@ -5,6 +5,6 @@
   {:options ["--cover"     "cover.png"
              "--cover-alt" "{{project-name|capitalize}}"]}}
  :sources
- {:main    ["src/*.dg"]
-  :debug   ["lib/dialog/stddebug.dg"]
-  :library ["lib/dialog/stdlib.dg"]}}
+ {:main    ["src"]
+  :debug   ["lib/dialog/debug"]
+  :library ["lib/dialog"]}}

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -154,6 +154,8 @@
         skein-paths (if skein-file
                       [skein-file]
                       (map str (fs/glob "" "*.skein")))
+        _ (when-not (seq skein-paths)
+            (fail "No skein files found"))
         width (->> skein-paths (map count) (apply max))
         test-totals (map #(run-tests project width %) skein-paths)
         totals (apply merge-with + test-totals)]

--- a/src/dialog_tool/skein/process.clj
+++ b/src/dialog_tool/skein/process.clj
@@ -87,7 +87,7 @@
 (defn- start-frotz-process
   [project seed debug?]
   (let [{project-name :name} project
-        project-dir (pf/project-dir project)
+        project-dir (pf/root-dir project)
         output-dir (fs/path project-dir "out" "skein" (if debug? "debug" "release"))
         path (fs/path output-dir (str project-name ".zblorb"))
         pre (fn []

--- a/src/dialog_tool/template.clj
+++ b/src/dialog_tool/template.clj
@@ -92,7 +92,7 @@
                (fs/path dir' "lib" "dialog" "stdlib.dg"))
 
     (copy-file (fs/path dialog-root "stddebug.dg")
-               (fs/path dir' "lib" "dialog" "stddebug.dg"))
+               (fs/path dir' "lib" "dialog" "debug" "stddebug.dg"))
 
     (copy-resource "template/default-cover.png"
                    (fs/path dir' "cover.png"))


### PR DESCRIPTION
With a little tweak to initial project setup this is much easier, no globs to worry about.