### PR TITLE
Skein Improvements

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -4,7 +4,7 @@
 
 - Visual feedback when the skein changes
 - The graph view (currently it's just a serial view, one path through the graph)
-- Collapsable text
+- Collapsable text (hide text, allow for quick navigation)
 - Buttons to jump to next/prev command
 - Animation when adding/removing nodes
 - Search the Skein
@@ -14,6 +14,9 @@
 - Recognize when the `dgdebug` command fails to launch entirely (currently, results in :unblessed as null)
 - Detect/report network failures
 - Shutdown the skein window (and server)
+- Color-blind indicators or mode
+- Restart should rebuild the source file list, re-read the dialog.edn
+- Monitor the file system for (specific) changes, use a webhook, optional auto-replay-all on change
 
 ## Releasing
 

--- a/skein-ui/src/App.svelte
+++ b/skein-ui/src/App.svelte
@@ -23,7 +23,9 @@
     FloppyDiskAltSolid,
     PlaySolid,
     ChevronDownOutline,
+    CloseCircleSolid
   } from "flowbite-svelte-icons";
+    import QuitModal from "./lib/QuitModal.svelte";
 
   let knots = new SvelteMap<number, KnotData>();
   let scrollToId = $state(null);
@@ -44,6 +46,7 @@
   let alertMessage: string = $state(null);
   let modalAlertRunning = $state(false);
   let dirty = $state(false);
+  let showQuit = $state(false);
 
   function alert(message: string): void {
     alertMessage = message;
@@ -144,6 +147,8 @@
   async function focusNewCommand(id: number): Promise<void> {
     postPayload({ action: "deselect", id: id });
   }
+ 
+
 </script>
 
 <div class="relative px-8">
@@ -192,6 +197,9 @@
       <Button color="blue" size="xs" on:click={redo} disabled={!enableRedo}>
         <RedoOutline class="w-5 h-5 me-2" />Redo</Button
       >
+      <Button color="blue" size="xs" on:click={ () => showQuit = true }>
+          <CloseCircleSolid class="w-5 h-5 me-2"/>Quit 
+      </Button>
     </div>
   </Navbar>
 
@@ -220,3 +228,4 @@
 
 <ReplayAllModal {knots} {processResult} bind:this={replayAllModal} />
 <ModalAlert message={alertMessage} bind:running={modalAlertRunning} />
+<QuitModal dirty={dirty} bind:running={showQuit}/>

--- a/skein-ui/src/App.svelte
+++ b/skein-ui/src/App.svelte
@@ -43,6 +43,7 @@
   let enableRedo = $state(false);
   let alertMessage: string = $state(null);
   let modalAlertRunning = $state(false);
+  let dirty = $state(false);
 
   function alert(message: string): void {
     alertMessage = message;
@@ -65,6 +66,7 @@
 
     enableUndo = result.enable_undo;
     enableRedo = result.enable_redo;
+    dirty = result.dirty;
 
     const focus =  result.focus;
 
@@ -181,7 +183,7 @@
         <PlaySolid class="w-5 h-5 me-2" />Replay All</Button
       >
       <Tooltip>Replay <em>every</em> knot</Tooltip>
-      <Button color="blue" size="xs" on:click={save}>
+      <Button color={ dirty ? 'blue' : 'green'} size="xs" on:click={save}>
         <FloppyDiskAltSolid class="w-5 h-5 me-2" /> Save</Button
       >
       <Button color="blue" size="xs" on:click={undo} disabled={!enableUndo}>

--- a/skein-ui/src/lib/Knot.svelte
+++ b/skein-ui/src/lib/Knot.svelte
@@ -214,12 +214,6 @@
                             Edit Command
                             <Helper>Change the command</Helper>
                         </DropdownItem>
-                    {/if}
-                    <DropdownItem onclick={newChild} class={ddcolor}>
-                        New Child
-                        <Helper>Add a new command after this</Helper>
-                    </DropdownItem>
-                    {#if knot.id != 0}
                         <DropdownItem
                             onclick={() => activateField(insertParent)}
                             class={ddcolor}
@@ -227,7 +221,11 @@
                             Insert Parent
                             <Helper>Insert a command before this</Helper>
                         </DropdownItem>
-                    {/if}
+                    {/if}                    
+                    <DropdownItem onclick={newChild} class={ddcolor}>
+                        New Child
+                        <Helper>Add a new command after this</Helper>
+                    </DropdownItem>
                 </Dropdown>
                 {#if knot.children.length > 0}
                     <Button

--- a/skein-ui/src/lib/Knot.svelte
+++ b/skein-ui/src/lib/Knot.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
     import { category2color } from "./knot-color";
     import { postApi, type ActionResult, type Payload } from "./common.svelte";
-    import { Button, Dropdown, DropdownItem, Helper } from "flowbite-svelte";
+    import { Button, Dropdown, DropdownItem, Helper, Indicator } from "flowbite-svelte";
     import KnotText from "./KnotText.svelte";
     import EditProperty from "./EditProperty.svelte";
     import { DotsVerticalOutline, CodeMergeSolid } from "flowbite-svelte-icons";
@@ -236,6 +236,9 @@
                         size="xs"
                     >
                         <CodeMergeSolid class="w-4 h-4" />
+                        {#if knot.children.length > 1}
+                        <Indicator size="xl" border placement="top-right">{knot.children.length}</Indicator>
+                        {/if}
                     </Button>
                     <Dropdown
                         placement="left"

--- a/skein-ui/src/lib/Knot.svelte
+++ b/skein-ui/src/lib/Knot.svelte
@@ -235,7 +235,7 @@
                     >
                         <CodeMergeSolid class="w-4 h-4" />
                         {#if knot.children.length > 1}
-                        <Indicator size="xl" border placement="top-right">{knot.children.length}</Indicator>
+                        <Indicator class={controlColor.background} size="xl" border placement="top-right">{knot.children.length}</Indicator>
                         {/if}
                     </Button>
                     <Dropdown

--- a/skein-ui/src/lib/QuitModal.svelte
+++ b/skein-ui/src/lib/QuitModal.svelte
@@ -1,0 +1,42 @@
+<script lang="ts">
+    import { postApi } from "./common.svelte";
+    import { Modal, Button } from "flowbite-svelte";
+
+interface Props {
+    dirty : boolean,
+    running : boolean
+}
+
+let { dirty, running = $bindable() } : Props = $props()
+
+async function quit () {
+    await postApi({action: "quit"});
+
+    window.close()
+}
+
+async function save() {
+    await postApi({action: "save"});
+
+    quit()
+}
+
+</script>
+
+<Modal title="Quit"
+bind:open={running}
+size="sm">
+        Really quit? 
+        {#if dirty}
+        <p>
+        Unsaved progress will be lost.
+        </p>
+        {/if}
+    <svlete:fragment slot="footer">
+        <Button color="blue" on:click={ () => running = false }>Cancel</Button>
+        {#if dirty} 
+        <Button color="blue" on:click={ save }>Save First</Button>
+        {/if}
+        <Button color={ dirty ? 'red' : 'blue'}>Quit</Button>
+    </svlete:fragment>
+</Modal>

--- a/skein-ui/src/lib/common.svelte.ts
+++ b/skein-ui/src/lib/common.svelte.ts
@@ -18,6 +18,7 @@ export type ActionResult = {
     focus: number,
     enable_undo: boolean,
     enable_redo: boolean,
+    dirty: boolean,
     // Only for new-command:
     new_id?: number,
     // Only appears for GET /api request:
@@ -46,8 +47,6 @@ export async function postApi(payload: Payload): Promise<ActionResult> {
 }
 
 export function mergeCategory(left: Category, right: Category): Category {
-    // TODO: all this is really the max of the two inputs
-
     if (left == "error" || right == "error") { return "error"; }
 
     if (left == "new" || right == "new") { return "new"; }

--- a/src/dialog_tool/skein/handlers.clj
+++ b/src/dialog_tool/skein/handlers.clj
@@ -33,7 +33,8 @@
     ;; sending just what's changed.
     {:updates     (mapv tree/knot->wire updates)
      :removed_ids removed-ids
-     :focus       (:focus new-tree)}))
+     :focus       (:focus new-tree)
+     :dirty       (:dirty? new-tree)}))
 
 (defn- bless
   [session payload]

--- a/src/dialog_tool/skein/service.clj
+++ b/src/dialog_tool/skein/service.clj
@@ -82,6 +82,10 @@
           "../sanddancer-dialog/default.skein"
           {:engine :dgdebug})
 
+  (start! (pf/read-project "../dialog-extensions/who")
+          "../dialog-extensions/who/default.skein"
+          nil)
+
   (start! (pf/read-project "../sanddancer-dialog")
           "../sanddancer-dialog/frotz.skein"
           {:seed   10101

--- a/src/dialog_tool/skein/service.clj
+++ b/src/dialog_tool/skein/service.clj
@@ -21,7 +21,8 @@
   ;; This is to allow code reloading to work correctly without restarting
   ;; the service.
   ((requiring-resolve 'dialog-tool.skein.handlers/service-handler)
-   (assoc request :*session *session)))
+   (assoc request :*session *session
+                  :*shutdown *shutdown)))
 
 (defn start!
   "Starts a service with the Skein for the given path, or a new empty skein
@@ -92,6 +93,7 @@
            :engine :frotz})
 
   (@*shutdown)
+
 
   (->> "attack-cage-with-strength.txt
 base-of-tower.txt

--- a/src/dialog_tool/skein/session.clj
+++ b/src/dialog_tool/skein/session.clj
@@ -74,7 +74,7 @@
 
 (defn- do-restart!
   [session]
-  ;; First pass made use of '(restart)' but that had problems, and dgdebug is so fast
+  ;; An earlier version made use of '(restart)' but that had problems, and dgdebug is so fast
   ;; to start up that it doesn't make sense.
   (let [{:keys [process]} session
         process' (sk.process/restart! process)
@@ -180,7 +180,9 @@
   [session]
   (let [{:keys [tree skein-path]} session]
     (sk.file/save-tree tree skein-path)
-    session))
+    ;; If this moves around the undo/redo stack, may not get the right
+    ;; behavior, maybe. Not sure.
+    (assoc session :tree (tree/clean tree))))
 
 (defn undo
   "Undoes the state of the tree one step; the current tree is pushed onto the


### PR DESCRIPTION
- Add an indicator to the child drop down of a knot with the child count (if > 1)
- Track whether the skein is unsaved (aka "dirty")
- Highlight the save button in green if saved, or blue if dirty
- Add a quit button to the top bar
- Add a quit dialog, with option to save first (if dirty)
- Quit shuts down server, closes window
- Move the "Add Child" action to the bottom of the action drop-down list