### PR TITLE
Rename :format to :target throughout the project

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+## Project Overview
+
+`dgt` (Dialog Tool) is a CLI tool for developing interactive fiction written in the
+[Dialog](https://github.com/dialog-if/dialog) language. It is implemented in Clojure and
+distributed as an uberjar.
+
+The tool provides commands for:
+- Creating new projects from a template (`dgt new`)
+- Running projects in the Dialog debugger (`dgt debug`)
+- Running a web-based Skein UI for interactive testing (`dgt skein`)
+- Building projects to various targets (`dgt build`)
+- Bundling projects for web deployment (`dgt bundle`)
+- Running projects via frotz (`dgt run`)
+
+## Project Structure
+
+- `src/dialog_tool/` — Main source code
+  - `main.clj` — Entry point, CLI dispatch
+  - `commands.clj` — Top-level CLI commands (build, debug, run, new, etc.)
+  - `build.clj` — Compilation via external `dialogc` compiler
+  - `bundle.clj` — Web bundle packaging
+  - `project_file.clj` — Reading and processing `dialog.edn` project files
+  - `template.clj` — Project template creation
+  - `skein/` — Skein subsystem (session management, tree structure, web UI, process control)
+- `test/` — Tests (run with `bb test` or `clj -M:test`)
+- `resources/` — Templates, bundled assets, skein resources
+- `release/` — Babashka release scripts and Homebrew formula template
+- `build.clj` — tools.build uberjar configuration
+
+## Key Technologies
+
+- **Clojure** with `deps.edn` for dependency management
+- **Babashka** (`bb.edn`) for task running (tests, releases, tailwind)
+- **cli-tools** (`io.github.hlship/cli-tools`) for CLI option parsing and command dispatch
+- **Datastar** + **Huff** + **DaisyUI** for the Skein web UI
+- **http-kit** as the web server
+- **pty4j** for pseudo-terminal process interaction with `dgdebug`
+
+## Development
+
+- `bb test` — Run the test suite
+- `bb tailwind` — Watch and rebuild CSS (requires `npm install` and `brew install tailwindcss`)
+- REPL-driven development via nREPL (`:dev` alias adds dev paths and reload tooling)
+
+## Configuration
+
+Each Dialog project has a `dialog.edn` at its root. Key fields:
+- `:name` — Project name
+- `:target` — Build target (`:zblorb`, `:z5`, `:z8`, `:aa`)
+- `:build` — Per-target build options (e.g., cover image flags)
+- `:sources` — Source directories organized as `:main`, `:debug`, `:library`
+
+## Important Rules
+
+- **Never commit or push without explicit approval from the user.**
+- The `--format` flag passed to external tools (`dialogc`, `aambundle`) is the *external tool's* flag
+  and is unrelated to the project's `:target` configuration key.
+- `CHANGES.md` is a historical record; do not retroactively alter past entries.

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A minimal example `dialog.edn` (as created by `dgt new`):
  
 ```
 {:name "magnum-opus"
- :format :zblorb
+ :target :zblorb
  :build
  {:zblorb
   {:options ["--cover"     "cover.png" 
@@ -133,24 +133,24 @@ Alternately, a source may be a specific file, which is simply added to the list 
 If you are coming to `dgt` from a different approach, it may be easier to just list all the files, in order,
 in your `dialog.edn`, but if you are starting from scratch, the directory-based approach is easier.
 
-### Format
+### Target
 
-The :format key defines the output when the project is built; :zblorb is a good general choice.
+The :target key defines the output when the project is built; :zblorb is a good general choice.
 In specific situations you may want to build for :z5, :z8, or :aa.  The differences between
-these formats are described in [the Dialog manual](https://dialog-if.github.io/manual/dialog/1a01/software.html).
+these targets are described in [the Dialog manual](https://dialog-if.github.io/manual/dialog/1a01/software.html).
 
-`dgt build` only builds the one format, but has command line options to override the format from what's
+`dgt build` only builds the one target, but has command line options to override the target from what's
 in `dialog.edn`.
 
 ### Build Config
 
-The :build key contains build configuration for each format. When bundling, you may build once according
-to the project's format, and a second time in :aa format for the web.
+The :build key contains build configuration for each target. When bundling, you may build once according
+to the project's target, and a second time in :aa target for the web.
 
 The :options key is used to specify additional options to add to the `dialogc` command line.
 This is typically used to set the heap size information.
 
-Under :build, the :default key contains defaults for building (any format); the specific build map (:zblorb, in our example)
+Under :build, the :default key contains defaults for building (any target); the specific build map (:zblorb, in our example)
 is merged on top of the :default map, if present.
 
 ### Bin Dir
@@ -219,7 +219,7 @@ to completion.
 
 ## Building and Bundling
 
-The `dgt build` command is used to build your project; the :format key of `dialog.edn` determines how it
+The `dgt build` command is used to build your project; the :target key of `dialog.edn` determines how it
 will be built; the default is :zblorb; The [ZBlorb format](https://en.wikipedia.org/wiki/Blorb) can contain not only the compiled output of your project, but
 also sounds and images.
 

--- a/resources/template/dialog.edn
+++ b/resources/template/dialog.edn
@@ -1,5 +1,5 @@
 {:name   "{{project-name}}"
- :format :zblorb
+ :target :zblorb
  :build
  {:zblorb
   {:options ["--cover"     "cover.png"

--- a/src/dialog_tool/build.clj
+++ b/src/dialog_tool/build.clj
@@ -7,13 +7,13 @@
             [net.lewisship.cli-tools :as cli]))
 
 (defn- dialogc-args
-  [format options project output-path]
+  [target options project output-path]
   (let [{:keys [verbose? debug?]} options
         {:keys [build]} project
         build'        (merge (:default build)
-                             (get build format))
+                             (get build target))
         build-options (:options build')]
-    (cond-> ["--format" (name format)
+    (cond-> ["--format" (name target)
              "--output" (str output-path)]
 
       verbose? (conj "--verbose")
@@ -26,12 +26,12 @@
   "Invokes dialogc to compile the sources from the project.
 
   Returns the path to the compiled file."
-  [format project sources output-dir options]
-  (let [ext         (if (= format :aa)
+  [target project sources output-dir options]
+  (let [ext         (if (= target :aa)
                       "aastory"
-                      (name format))
+                      (name target))
         output-path (fs/path output-dir (str (:name project) "." ext))
-        args        (into (dialogc-args format options project output-path)
+        args        (into (dialogc-args target options project output-path)
                           sources)
         command     (into [(pf/command-path project "dialogc")] args)
         _           (do
@@ -46,11 +46,11 @@
 (defn build-project
   "Builds a project; returns the path of the compiled file."
   [project options]
-  (let [{:keys [format debug?]} options
-        format     (or format (:format project))
-        _     (when-not format
-                (cli/abort "No :format defined for project"))
+  (let [{:keys [target debug?]} options
+        target     (or target (:target project))
+        _     (when-not target
+                (cli/abort "No :target defined for project"))
         output-dir (fs/path "out" (if debug? "debug" "release"))
         sources    (pf/expand-sources project options)]
     (fs/create-dirs output-dir)
-    (invoke-dialogc format project sources output-dir options)))
+    (invoke-dialogc target project sources output-dir options)))

--- a/src/dialog_tool/bundle.clj
+++ b/src/dialog_tool/bundle.clj
@@ -63,9 +63,9 @@
   [project]
   (let [project-name (:name project)
         compiled-path (build/build-project project nil)
-        aa-path (if (= :aa (:format project))
+        aa-path (if (= :aa (:target project))
                   compiled-path
-                  (build/build-project project {:format :aa}))
+                  (build/build-project project {:target :aa}))
         compiled-name (fs/file-name compiled-path)
         story (extract-story-info project)
         zip-file (fs/path "." "out" (str project-name "-" (:release story) ".zip"))
@@ -112,7 +112,7 @@
                        {:story story
                         :story-file compiled-name
                         :story-file-description (str
-                                                 (-> project :format name)
+                                                 (-> project :target name)
                                                  " "
                                                  (-> compiled-path
                                                      fs/size

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -53,14 +53,14 @@
 
 (defcommand build
   "Compile the project to a file ready to execute with an interpreter."
-  [format (cli/select-option "-f" "--format FORMAT"
-                             "Output format:"
+  [target (cli/select-option "-t" "--target TARGET"
+                             "Output target:"
                              #{:zblorb :z5 :z8 :aa})
    debug? debug-opt
    verbose ["-v" "--verbose" "Enable additional compiler output"]]
   (build/build-project (pf/read-project)
                        {:debug? debug?
-                        :verbose? verbose :format format}))
+                        :verbose? verbose :target target}))
 
 (defcommand bundle
   "Bundle the project into a Zip archive that can be deployed to a web host."
@@ -70,7 +70,7 @@
 (defcommand run-project
   "Runs the project using the frotz command.
 
-  Note: --dumb has output format issues.
+  Note: --dumb has output target issues.
 
   Use -- before any frotz arguments.
   "
@@ -83,14 +83,14 @@
                :repeatable true]
    :command "run"]
   (let [project (pf/read-project)
-        {:keys [format]} project
-        format' (if (= format :aa)
+        {:keys [target]} project
+        target' (if (= target :aa)
                   (do
-                    (perr [:faint "Project format is aa; compiling to z8 for frotz"])
+                    (perr [:faint "Project target is aa; compiling to z8 for frotz"])
                     :z8)
-                  format)
+                  target)
         path    (build/build-project project
-                                     {:format format'
+                                     {:target target'
                                       :debug? debug?})
         command (concat [(if dumb? "dfrotz" "frotz")]
                         (when dumb?

--- a/test-fixtures/colors/dialog.edn
+++ b/test-fixtures/colors/dialog.edn
@@ -1,5 +1,5 @@
 {:name   "Kaleidoscope"
- :format :zblorb
+ :target :zblorb
  :build
  {:zblorb
   {:options ["--cover"     "cover.png"

--- a/test-fixtures/dgsample/dialog.edn
+++ b/test-fixtures/dgsample/dialog.edn
@@ -1,5 +1,5 @@
 {:name   "The Orb"
- :format :zblorb
+ :target :zblorb
  :build
  {:zblorb
   {:options ["--cover"     "cover.png"


### PR DESCRIPTION
The project configuration key :format has been renamed to :target to better describe its purpose (the build output target).

Changes:
- Rename :format → :target in build.clj, commands.clj, bundle.clj
- Rename CLI option from -f/--format to -t/--target
- Update dialog.edn template and test fixtures
- Update README.md documentation
- Add CLAUDE.md with project overview and guidelines

The --format flag passed to external tools (dialogc, aambundle) is unchanged as it belongs to those tools' CLI interfaces.

🤖 Generated with [eca](https://eca.dev)