### PR TITLE
Support multiple build targets in dialog.edn

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,8 @@ The tool provides commands for:
 
 Each Dialog project has a `dialog.edn` at its root. Key fields:
 - `:name` — Project name
-- `:target` — Build target (`:zblorb`, `:z5`, `:z8`, `:aa`)
+- `:target` — Build target(s): a single keyword (`:zblorb`) or a vector of keywords (`[:zblorb :aa]`).
+  Normalized to a vector internally by `project_file.clj`.
 - `:build` — Per-target build options (e.g., cover image flags)
 - `:sources` — Source directories organized as `:main`, `:debug`, `:library`
 

--- a/README.md
+++ b/README.md
@@ -135,17 +135,19 @@ in your `dialog.edn`, but if you are starting from scratch, the directory-based 
 
 ### Target
 
-The :target key defines the output when the project is built; :zblorb is a good general choice.
+The :target key defines the output when the project is built. It may be a single keyword
+(e.g., `:target :zblorb`) or a vector of keywords (e.g., `:target [:zblorb :z8]`).
+:zblorb is a good general choice.
 In specific situations you may want to build for :z5, :z8, or :aa.  The differences between
 these targets are described in [the Dialog manual](https://dialog-if.github.io/manual/dialog/1a01/software.html).
 
-`dgt build` only builds the one target, but has command line options to override the target from what's
-in `dialog.edn`.
+`dgt build` builds all targets defined in the project; use the `--target` option to build
+a single specific target instead.
 
 ### Build Config
 
-The :build key contains build configuration for each target. When bundling, you may build once according
-to the project's target, and a second time in :aa target for the web.
+The :build key contains build configuration for each target. When bundling, all project targets
+are built, plus :aa (for the web player) if not already included.
 
 The :options key is used to specify additional options to add to the `dialogc` command line.
 This is typically used to set the heap size information.

--- a/resources/bundle/index.html
+++ b/resources/bundle/index.html
@@ -16,7 +16,9 @@
 </div>
 <div class="links">
 	<ul>
-	<li><div class="download"><a href="{{story-file}}">Story File</a> <span class="filetype">({{story-file-description}})</span></div></li>
+	{% for sf in story-files %}
+	<li><div class="download"><a href="{{sf.name}}">Story File</a> <span class="filetype">({{sf.description}})</span></div></li>
+	{% endfor %}
 	<div class="auxiliary">
 		<li><a href="introduction-to-if.pdf">Introduction to IF</a> <span class="filetype">(pdf,&nbsp;612KB)</span></li>
 		<li><a href="play-if-card.pdf">IF in One Page</a> <span class="filetype">(pdf, 263KB)</li>

--- a/src/dialog_tool/build.clj
+++ b/src/dialog_tool/build.clj
@@ -10,8 +10,8 @@
   [target options project output-path]
   (let [{:keys [verbose? debug?]} options
         {:keys [build]} project
-        build'        (merge (:default build)
-                             (get build target))
+        build' (merge (:default build)
+                      (get build target))
         build-options (:options build')]
     (cond-> ["--format" (name target)
              "--output" (str output-path)]
@@ -27,30 +27,29 @@
 
   Returns the path to the compiled file."
   [target project sources output-dir options]
-  (let [ext         (if (= target :aa)
-                      "aastory"
-                      (name target))
+  (let [ext (if (= target :aa)
+              "aastory"
+              (name target))
         output-path (fs/path output-dir (str (:name project) "." ext))
-        args        (into (dialogc-args target options project output-path)
-                          sources)
-        command     (into [(pf/command-path project "dialogc")] args)
-        _           (do
-                      (perr [:cyan "Building " output-path " ..."])
-                      (env/debug-command command))
-        {:keys [exit]} @(p/process {:cmd     command
+        args (into (dialogc-args target options project output-path)
+                   sources)
+        command (into [(pf/command-path project "dialogc")] args)
+        _ (do
+            (perr [:cyan "Building " output-path " ..."])
+            (env/debug-command command))
+        {:keys [exit]} @(p/process {:cmd command
                                     :inherit true})]
     (when-not (zero? exit)
       (cli/exit exit))
     output-path))
 
 (defn build-project
-  "Builds a project; returns the path of the compiled file."
+  "Builds a project for a single target; returns the path of the compiled file.
+
+  The target to build is specified via the :target key in options (a single keyword)."
   [project options]
   (let [{:keys [target debug?]} options
-        target     (or target (:target project))
-        _     (when-not target
-                (cli/abort "No :target defined for project"))
         output-dir (fs/path "out" (if debug? "debug" "release"))
-        sources    (pf/expand-sources project options)]
+        sources (pf/expand-sources project options)]
     (fs/create-dirs output-dir)
     (invoke-dialogc target project sources output-dir options)))

--- a/src/dialog_tool/bundle.clj
+++ b/src/dialog_tool/bundle.clj
@@ -59,14 +59,29 @@
                (map #(ansi/strip-ansi (:response %)))
                (reduce str)))))))
 
+(defn- build-target
+  "Builds a single target, returning a map with :target, :path, :name, and :description."
+  [project target]
+  (let [path (build/build-project project {:target target})]
+    {:target target
+     :path path
+     :name (str (fs/file-name path))
+     :description (str (name target)
+                       " "
+                       (-> path fs/size h/filesize))}))
+
 (defn bundle-project
   [project]
   (let [project-name (:name project)
-        compiled-path (build/build-project project nil)
-        aa-path (if (= :aa (:target project))
-                  compiled-path
-                  (build/build-project project {:target :aa}))
-        compiled-name (fs/file-name compiled-path)
+        targets (:target project)
+        ;; Build all unique targets needed: project targets + :aa for web player
+        all-targets (distinct (conj (vec targets) :aa))
+        built (mapv #(build-target project %) all-targets)
+        built-by-target (into {} (map (juxt :target identity)) built)
+        ;; The :aa build is for the web player
+        aa-build (get built-by-target :aa)
+        ;; Story files are the non-:aa builds (for download)
+        story-files (filterv #(not= :aa (:target %)) built)
         story (extract-story-info project)
         zip-file (fs/path "." "out" (str project-name "-" (:release story) ".zip"))
         bundle-out-dir (fs/path "." "out" "web")]
@@ -80,7 +95,7 @@
     (p/shell (pf/command-path project "aambundle")
              "--target" "web"
              "--output" (str bundle-out-dir)
-             (str aa-path))
+             (str (:path aa-build)))
     (perr [:cyan "  out/web/resources/..."])
 
     ;; Overwrite the default style.css with this one
@@ -95,7 +110,10 @@
       (t/copy-resource (str "bundle/" source)
                        (fs/path bundle-out-dir source)))
 
-    (t/copy-file compiled-path (fs/path bundle-out-dir compiled-name))
+    ;; Copy all story files (non-:aa compiled outputs) into the bundle
+    (doseq [{:keys [path]} story-files]
+      (t/copy-file path (fs/path bundle-out-dir (str (fs/file-name path)))))
+
     (t/copy-file "cover.png" (fs/path bundle-out-dir "cover.png"))
 
     (perr [:cyan "  out/web/cover-small.jpg"])
@@ -110,13 +128,7 @@
                                            (-> path fs/size h/filesize))))]
       (t/copy-rendered "bundle/index.html"
                        {:story story
-                        :story-file compiled-name
-                        :story-file-description (str
-                                                 (-> project :target name)
-                                                 " "
-                                                 (-> compiled-path
-                                                     fs/size
-                                                     h/filesize))
+                        :story-files story-files
                         :walkthrough-description walkthrough-description}
                        (fs/path bundle-out-dir "index.html")))
 

--- a/src/dialog_tool/bundle.clj
+++ b/src/dialog_tool/bundle.clj
@@ -80,8 +80,10 @@
         built-by-target (into {} (map (juxt :target identity)) built)
         ;; The :aa build is for the web player
         aa-build (get built-by-target :aa)
-        ;; Story files are the non-:aa builds (for download)
-        story-files (filterv #(not= :aa (:target %)) built)
+        ;; Story files are for download; include :aa only if explicitly in project targets
+        story-files (if (some #{:aa} targets)
+                      built
+                      (filterv #(not= :aa (:target %)) built))
         story (extract-story-info project)
         zip-file (fs/path "." "out" (str project-name "-" (:release story) ".zip"))
         bundle-out-dir (fs/path "." "out" "web")]

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -52,15 +52,22 @@
                                  {:project-name (or project-name project-dir)}))
 
 (defcommand build
-  "Compile the project to a file ready to execute with an interpreter."
+  "Compile the project to a file ready to execute with an interpreter.
+
+  When --target is specified, builds for that single target.
+  Otherwise, builds for all targets defined in the project."
   [target (cli/select-option "-t" "--target TARGET"
                              "Output target:"
                              #{:zblorb :z5 :z8 :aa})
    debug? debug-opt
    verbose ["-v" "--verbose" "Enable additional compiler output"]]
-  (build/build-project (pf/read-project)
-                       {:debug? debug?
-                        :verbose? verbose :target target}))
+  (let [project (pf/read-project)
+        base-options {:debug? debug?
+                      :verbose? verbose}]
+    (if target
+      (build/build-project project (assoc base-options :target target))
+      (doseq [t (:target project)]
+        (build/build-project project (assoc base-options :target t))))))
 
 (defcommand bundle
   "Bundle the project into a Zip archive that can be deployed to a web host."
@@ -83,15 +90,16 @@
                :repeatable true]
    :command "run"]
   (let [project (pf/read-project)
-        {:keys [target]} project
-        target' (if (= target :aa)
-                  (do
-                    (perr [:faint "Project target is aa; compiling to z8 for frotz"])
-                    :z8)
-                  target)
-        path    (build/build-project project
-                                     {:target target'
-                                      :debug? debug?})
+        targets (:target project)
+        ;; frotz can't run :aa targets; pick the first non-:aa target,
+        ;; or fall back to :z8 if only :aa is available
+        target (or (first (remove #{:aa} targets))
+                   (do
+                     (perr [:faint "Project target is aa; compiling to z8 for frotz"])
+                     :z8))
+        path (build/build-project project
+                                  {:target target
+                                   :debug? debug?})
         command (concat [(if dumb? "dfrotz" "frotz")]
                         (when dumb?
                           ["-m" "-q"])

--- a/src/dialog_tool/project_file.clj
+++ b/src/dialog_tool/project_file.clj
@@ -7,13 +7,25 @@
            (java.nio.file.attribute FileTime)
            (java.security MessageDigest)))
 
+(defn- normalize-target
+  "Normalizes the :target key to always be a vector of keywords.
+  A single keyword (e.g., :zblorb) becomes [:zblorb]; a sequence stays as-is.
+  Also supports the legacy :format key (renamed to :target).
+  Defaults to [:zblorb] when neither :target nor :format is specified."
+  [project]
+  (let [target (or (:target project) (:format project))]
+    (cond-> (dissoc project :format)
+      (keyword? target) (assoc :target [target])
+      (sequential? target) (assoc :target (vec target))
+      (nil? target) (assoc :target [:zblorb]))))
+
 (defn read-project
   ;; 0 arity is normal, 1 arity is just for testing purposes
   ([]
    (read-project ""))
   ([root-dir]
    (let [root-dir' (fs/path (or root-dir ""))
-         path (fs/path root-dir '"dialog.edn")]
+         path (fs/path root-dir' "dialog.edn")]
      (when-not (fs/exists? path)
        (abort (str path) " does not exist"))
      (try
@@ -21,10 +33,11 @@
            fs/file
            slurp
            edn/read-string
+           normalize-target
            (assoc ::root-dir root-dir'))
        (catch Throwable t
          (abort "Could not read " [:bold path] ": "
-               (ex-message t)))))))
+                (ex-message t)))))))
 
 (defn- expand-source
   [root-dir source]
@@ -47,13 +60,13 @@
    (expand-sources project nil))
   ([project {:keys [debug? pre-patch]}]
    (let [{::keys [root-dir]
-          :keys  [sources]} project
+          :keys [sources]} project
          {:keys [main debug library]} sources
          sources (concat
-                   pre-patch
-                   main
-                   (when debug? debug)
-                   library)]
+                  pre-patch
+                  main
+                  (when debug? debug)
+                  library)]
      (->> sources
           (mapcat #(expand-source root-dir %))
           (map str)))))
@@ -66,7 +79,7 @@
   [^MessageDigest digest ^Path f]
   (let [^FileTime last-modified (-> (fs/read-attributes f "lastModifiedTime")
                                     :lastModifiedTime)
-        b                       (ByteBuffer/allocate 8)]
+        b (ByteBuffer/allocate 8)]
     (.putLong b (.toMillis last-modified))
     (.flip b)
     (.update digest b)))
@@ -86,16 +99,16 @@
   the hash."
   [project]
   (let [{::keys [root-dir]
-         :keys  [sources]} project
+         :keys [sources]} project
         {:keys [main debug library]} sources
-        digest    (MessageDigest/getInstance "SHA-1")
+        digest (MessageDigest/getInstance "SHA-1")
         root-path (fs/path root-dir "dialog.edn")
-        _         (->> [main debug library]
-                       (reduce into [root-path])
-                       (mapcat #(expand-source root-dir %))
-                       sort
-                       (run! #(update-digest-from-file digest %)))
-        bs        (.digest digest)]
+        _ (->> [main debug library]
+               (reduce into [root-path])
+               (mapcat #(expand-source root-dir %))
+               sort
+               (run! #(update-digest-from-file digest %)))
+        bs (.digest digest)]
     ;; Byte arrays don't compare as equals, so convert to a hex string
     ;; for later comparison.
     (hex-string bs)))


### PR DESCRIPTION
The :target key in dialog.edn can now be a single keyword or a vector
of keywords (e.g., :target [:zblorb :aa]).

Changes:
- project_file.clj: normalize-target coerces :target to a vector,
  supports legacy :format key, defaults to [:zblorb]
- build.clj: build-project simplified to always expect :target in options
- commands.clj: build command iterates over all project targets when
  no --target flag is given; run command picks first non-:aa target
- bundle.clj: builds all project targets plus :aa for web player,
  bundles all non-:aa compiled outputs as downloadable story files
- resources/bundle/index.html: loops over story-files for downloads
- Updated README.md and CLAUDE.md

Closes #30