### PR TITLE
Add .exe extension to external commands on Windows

### DIFF
--- a/src/dialog_tool/bundle.clj
+++ b/src/dialog_tool/bundle.clj
@@ -119,7 +119,7 @@
     (t/copy-file "cover.png" (fs/path bundle-out-dir "cover.png"))
 
     (perr [:cyan "  out/web/cover-small.jpg"])
-    (p/shell "magick cover.png -resize 120 out/web/cover-small.jpg")
+    (p/shell (pf/command-path project "magick") "cover.png" "-resize" "120" "out/web/cover-small.jpg")
 
     (let [walkthrough (extract-walkthrough project)
           walkthrough-description (when walkthrough

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -100,7 +100,7 @@
         path (build/build-project project
                                   {:target target
                                    :debug? debug?})
-        command (concat [(if dumb? "dfrotz" "frotz")]
+        command (concat [(pf/command-path project (if dumb? "dfrotz" "frotz"))]
                         (when dumb?
                           ["-m" "-q"])
                         frotz-args

--- a/src/dialog_tool/project_file.clj
+++ b/src/dialog_tool/project_file.clj
@@ -113,9 +113,17 @@
     ;; for later comparison.
     (hex-string bs)))
 
+(def ^:private windows?
+  (-> (System/getProperty "os.name")
+      (.toLowerCase)
+      (.contains "win")))
+
 (defn command-path
   [project command]
-  (let [{:keys [bin-dir]} project]
+  (let [{:keys [bin-dir]} project
+        command' (if windows?
+                   (str command ".exe")
+                   command)]
     (if bin-dir
-      (str bin-dir "/" command)
-      command)))
+      (str bin-dir "/" command')
+      command')))

--- a/src/dialog_tool/skein/process.clj
+++ b/src/dialog_tool/skein/process.clj
@@ -156,7 +156,7 @@
         output-dir (fs/path project-dir "out" "skein" (if debug? "debug" "release"))
         path (fs/path output-dir (str project-name ".zblorb"))
         pre (fn []
-              (let [command (into ["dialogc"
+              (let [command (into [(pf/command-path project "dialogc")
                                    "--format" "zblorb"
                                    "--output" (str path)]
                                   ;; the patch prevents the status line from being presented
@@ -166,7 +166,7 @@
                 (env/debug-command command)
                 (p/check
                  (p/sh command))))
-        cmd ["dfrotz"
+        cmd [(pf/command-path project "dfrotz")
              ;; Flags: quiet, no *more*
              "-q" "-m"
              ;; Although dfortz has "-f ansi", when enabled


### PR DESCRIPTION
All external command invocations (dialogc, dgdebug, aambundle, dfrotz, frotz, magick) now go through command-path in project_file.clj, which appends .exe on Windows. Previously some commands in process.clj, commands.clj, and bundle.clj were invoked with hardcoded names.
