### PR TITLE
feat: automatically replay all on skein launch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@ Rewritten in Babashka. Added the Skein for development and testing support.
 Added trace mode to the Skein: trace command execution through the Dialog debugger,
 with an interactive tree view, expand/collapse, and search (dgdebug engine only).
 
+The Skein now automatically performs a Replay All when first launched.
+
 # 1.4 -- 29 Sep 2020
 
 Remove the `bless` command; it is now all done from the `test` command.

--- a/README.md
+++ b/README.md
@@ -221,7 +221,8 @@ add new commands beneath any knot, and you can also rerun the project to any kno
 and the skein will identify any text that has changed.  You can even run *all* possible branches
 to completion.
 
-`dgt skein run` will open an existing skein.
+`dgt skein run` will open an existing skein. When launched, the Skein automatically
+replays all branches to ensure responses and dynamic state are up to date.
 
 ## Building and Bundling
 

--- a/src/dialog_tool/skein/handlers.clj
+++ b/src/dialog_tool/skein/handlers.clj
@@ -294,6 +294,7 @@
 (defn- replay-all
   "Replays to all leaf knots with SSE progress updates."
   [{:keys [*session] :as request}]
+  (swap! *session dissoc :replay-on-launch?)
   (utils/with-short-sse
     request
     (fn [sse-gen]
@@ -699,7 +700,9 @@
    (quit-without-saving req)
 
    "GET /app" req
-   (render-app req)
+   (if (:replay-on-launch? @(:*session req))
+     (replay-all req)
+     (render-app req))
 
    "GET /fab" req
    {:status 200

--- a/src/dialog_tool/skein/service.clj
+++ b/src/dialog_tool/skein/service.clj
@@ -75,7 +75,8 @@
                                 (System/exit 0)))]
     (reset! *session (assoc session
                             :development-mode? development-mode?
-                            :debug-enabled? (= engine' :dgdebug)))
+                            :debug-enabled? (= engine' :dgdebug)
+                            :replay-on-launch? true))
     (reset! *shutdown shutdown-service-fn)
     port'))
 

--- a/src/dialog_tool/skein/ui/app.clj
+++ b/src/dialog_tool/skein/ui/app.clj
@@ -114,8 +114,8 @@
   [tree knot]
   (let [{:keys [parent-id dynamic-state]} knot
         before-dynamic-state (-> (tree/get-knot tree parent-id) :dynamic-state)]
-    (if (and (seq dynamic-state)
-             (seq before-dynamic-state))
+    (when (and (seq dynamic-state)
+               (seq before-dynamic-state))
       (let [{:keys [added removed changed]} (dynamic/diff before-dynamic-state dynamic-state)
             tuples (->> []
                         (into (map #(vector :added %) added))
@@ -131,12 +131,7 @@
                :removed [:span.rounded-box.border.border-warning.bg-warning.bg-opacity-20.text-warning-content.px-2.py-1
                          [:span.font-bold.mr-1 "−"] predicate]
                :changed [:span.rounded-box.border.border-info.bg-info.bg-opacity-10.px-2.py-1
-                         predicate]))]))
-      ;; When missing dynamic state, warn user to replay
-      [:div.font-sans.inline-flex.items-center.gap-2.text-sm.bg-info.rounded-sm.opacity-75.px-2.py-1.mt-2
-       [:div.icon.icon-warning]
-       [:em "Replay to collect world state data"]])))
-
+                         predicate]))])))))
 (defn- render-children-navigation
   [tree knot]
   (let [children (tree/children tree knot)


### PR DESCRIPTION
When the Skein UI is first opened, it now performs a Replay All automatically, ensuring responses and dynamic state are up to date. Removes the "Replay to collect world state data" warning since it is no longer needed.

🤖 Generated with [eca](https://eca.dev)