### PR TITLE
Add dgt test command and sample unit test

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,8 @@ server-side actions instead of individual HTTP endpoints.
 `dgt new` now includes `lib/dialog/test/unit.dg` for unit testing support.
 Added `:test` source category to `dialog.edn`, loaded alongside `:debug` sources.
 
+Added `dgt test` command: runs unit tests defined by the project.
+
 # 1.4 -- 29 Sep 2020
 
 Remove the `bless` command; it is now all done from the `test` command.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ distributed as an uberjar.
 The tool provides commands for:
 - Creating new projects from a template (`dgt new`)
 - Running projects in the Dialog debugger (`dgt debug`)
+- Running project unit tests under `dgdebug --unit-test` with all sources (`dgt test`)
 - Running a web-based Skein UI for interactive testing (`dgt skein`)
 - Building projects to various targets (`dgt build`)
 - Bundling projects for web deployment (`dgt bundle`)

--- a/README.md
+++ b/README.md
@@ -215,6 +215,15 @@ as status bar updates; to verify these, you must run using Frotz.
 `dgt test` runs your project's unit tests, using all sources (:main, :debug, :test, and :library). 
 The exit status of the command is 0 if all unit test pass, or 1 if any tests fail.
 
+A new project includes a sample unit test that you can run:
+
+```text
+$ dgt test
+Attempting 1 test.
+Testing #sample-unit-test: Passed!
+1 test passed successfully.
+```
+
 ## Running the Skein
 
 The [Skein](doc/skein.md) is an interactive web interface for running, debugging, and

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ to your project, in which to locate source files. All Dialog source files _direc
 are included.
 
 * :main - sources specific to your project
-* :test - unit test sources, loaded when running tests (unit test support is forthcoming)
+* :test - unit test sources, loaded when running `dgt test`
 * :debug - used by the commands `skein test`, `debug`, `skein run`, etc.
 * :library - additional libraries, including the Dialog standard library
 
@@ -209,6 +209,11 @@ By default, debug sources are excluded, but you can run with the `--debug` switc
 
 Neither the debugger nor the Skein can present all the possible Dialog screen effects, such
 as status bar updates; to verify these, you must run using Frotz.
+
+## Running unit tests
+
+`dgt test` runs your project's unit tests, using all sources (:main, :debug, :test, and :library). 
+The exit status of the command is 0 if all unit test pass, or 1 if any tests fail.
 
 ## Running the Skein
 

--- a/resources/template/unit-tests.dg
+++ b/resources/template/unit-tests.dg
@@ -1,0 +1,9 @@
+%% This is a sample unit test which can be run with `dgt test`.
+
+%% You may have any number of unit test sources.
+%% Refer to the Dialog Manual for more information.
+
+#sample-unit-test
+(test *)
+(run *)
+    (42 = 42)

--- a/src/dialog_tool/commands.clj
+++ b/src/dialog_tool/commands.clj
@@ -23,14 +23,33 @@
    debug-args ["ARGS" "Additional arguments passed to dgdebug"
                :optional true
                :repeatable true]]
-  (let [project (pf/read-project)
+  (let [project    (pf/read-project)
         extra-args (cond-> []
                      width (conj "--width" width))
-        cmd (-> [(pf/command-path project "dgdebug") "--quit"]
-                (into extra-args)
-                (into debug-args)
-                (into (pf/expand-sources project {:debug? true})))
-        *process (p/process {:cmd cmd
+        cmd        (-> [(pf/command-path project "dgdebug") "--quit"]
+                       (into extra-args)
+                       (into debug-args)
+                       (into (pf/expand-sources project {:debug? true})))
+        _          (env/debug-command cmd)
+        *process   (p/process {:cmd     cmd
+                               :inherit true})
+        {:keys [exit]} @*process]
+    (cli/exit exit)))
+
+(defcommand test-project
+  "Run the project in the Dialog debugger with test sources included."
+  [:command "test"
+   :pass-through true
+   :args
+   debug-args ["ARGS" "Additional arguments passed to dgdebug"
+               :optional true
+               :repeatable true]]
+  (let [project  (pf/read-project)
+        cmd      (-> [(pf/command-path project "dgdebug") "--unit-test"]
+                     (into debug-args)
+                     (into (pf/expand-sources project {:debug? true :test? true})))
+        _        (env/debug-command cmd)
+        *process (p/process {:cmd     cmd
                              :inherit true})
         {:keys [exit]} @*process]
     (cli/exit exit)))
@@ -52,7 +71,7 @@
                  :optional true]]
   (template/create-from-template project-dir
                                  {:project-name (str (or project-name project-dir))
-                                  :flat? flat?}))
+                                  :flat?        flat?}))
 
 (defcommand build
   "Compile the project to a file ready to execute with an interpreter.
@@ -64,8 +83,8 @@
                              #{:zblorb :z5 :z8 :aa})
    debug? debug-opt
    verbose ["-v" "--verbose" "Enable additional compiler output"]]
-  (let [project (pf/read-project)
-        base-options {:debug? debug?
+  (let [project      (pf/read-project)
+        base-options {:debug?   debug?
                       :verbose? verbose}]
     (if target
       (build/build-project project (assoc base-options :target target))
@@ -96,13 +115,13 @@
         targets (:target project)
         ;; frotz can't run :aa targets; pick the first non-:aa target,
         ;; or fall back to :z8 if only :aa is available
-        target (or (first (remove #{:aa} targets))
-                   (do
-                     (perr [:faint "Project target is aa; compiling to z8 for frotz"])
-                     :z8))
-        path (build/build-project project
-                                  {:target target
-                                   :debug? debug?})
+        target  (or (first (remove #{:aa} targets))
+                    (do
+                      (perr [:faint "Project target is aa; compiling to z8 for frotz"])
+                      :z8))
+        path    (build/build-project project
+                                     {:target target
+                                      :debug? debug?})
         command (concat [(pf/command-path project (if dumb? "dfrotz" "frotz"))]
                         (when dumb?
                           ["-m" "-q"])
@@ -117,10 +136,10 @@
    test? ["-t" "--test" "Include test sources"]
    one? ["-1" "--single-line" "Output as a single line, colon-separated"]]
   (let [project (pf/read-project)
-        paths (pf/expand-sources project {:debug? debug? :test? test?})]
+        paths   (pf/expand-sources project {:debug? debug? :test? test?})]
     (if one?
       (println (string/join ":" paths))
       (let [longest (apply max (map count paths))]
         (doseq [path paths]
-          (pout [{:font :cyan
+          (pout [{:font  :cyan
                   :width longest} path]))))))

--- a/src/dialog_tool/template.clj
+++ b/src/dialog_tool/template.clj
@@ -38,7 +38,7 @@
   "Copies binary resource path (on the classpath) to a target path."
   [resource-path target]
   (setup-target target)
-  (with-open [in (-> resource-path io/resource io/input-stream)
+  (with-open [in  (-> resource-path io/resource io/input-stream)
               out (-> target maybe-create fs/file io/output-stream)]
     (io/copy in out)))
 
@@ -62,18 +62,30 @@
   path to :main in sources. When flat?, the individual file path is added;
   otherwise the directory."
   [sources dir flat? resource-path context file-name]
-  (let [target-path (str "src/" file-name)
-        source-entry (if flat? target-path "src")]
+  (let [{:keys [category]
+         :or   {category :main}} context
+        target-dir   (cond flat?
+                           "src"
+
+                           (= category :main)
+                           "src"
+
+                           :else
+                           "test")
+        target-path  (str target-dir "/" file-name)
+        source-entry (if flat? target-path target-dir)]
     (copy-rendered resource-path context (fs/path dir target-path))
-    (conj-source sources :main source-entry)))
+    (conj-source sources category source-entry)))
 
 (defn- add-lib
   "Copies a classpath resource to the project. When flat?, the file goes directly
   into base-dir; otherwise it goes into base-dir/sub-dir. The appropriate path
   is added to source-key in sources."
-  [sources dir flat? resource-path source-key base-dir sub-dir file-name]
-  (let [target-dir (if flat? base-dir (str base-dir "/" sub-dir))
-        target-path (str target-dir "/" file-name)
+  [sources dir flat? resource-path source-key sub-dir file-name]
+  (let [target-dir   (if flat?
+                       "src"
+                       (str "lib/" sub-dir))
+        target-path  (str target-dir "/" file-name)
         source-entry (if flat? target-path target-dir)]
     (copy-resource resource-path (fs/path dir target-path))
     (conj-source sources source-key source-entry)))
@@ -101,11 +113,14 @@
                       (add-source dir' flat? "template/project.dg"
                                   {}
                                   (str project-name ".dg"))
+                      (add-source dir' flat? "template/unit-tests.dg"
+                                  {:category :test}
+                                  "unit-tests.dg")
 
                       ;; Library sources (placement depends on flat?)
-                      (add-lib dir' flat? "template/stdlib.dg" :library "lib" "dialog" "stdlib.dg")
-                      (add-lib dir' flat? "template/stddebug.dg" :debug "lib" "dialog/debug" "stddebug.dg")
-                      (add-lib dir' flat? "template/unit.dg" :test "lib" "dialog/test" "unit.dg"))]
+                      (add-lib dir' flat? "template/stdlib.dg" :library "dialog" "stdlib.dg")
+                      (add-lib dir' flat? "template/stddebug.dg" :debug "dialog/debug" "stddebug.dg")
+                      (add-lib dir' flat? "template/unit.dg" :test "dialog/test" "unit.dg"))]
 
       (copy-rendered "template/dialog.edn"
                      {:project-name project-name


### PR DESCRIPTION
## Summary

- New `dgt test` subcommand: runs the project in `dgdebug --unit-test` with all sources loaded (`:main`, `:test`, `:debug`, `:library`). Exit status 0 on success, 1 on failure. Supports pass-through args after `--`.
- `dgt new` now scaffolds a `unit-tests.dg` containing a passing `#sample-unit-test`, so `dgt test` works immediately in a freshly created project. Files land in `src/` for `--flat` layouts and `test/` otherwise.
- Refactored `template.clj` to support a `:test` source category alongside `:main` when adding sources.
- Documented in `README.md`, `CHANGES.md` (2.0 section), and project `CLAUDE.md`.

## Test plan

- [ ] `clj -M:test` passes
- [ ] `dgt help` lists `test`
- [ ] `dgt new tmp/foo && cd tmp/foo && dgt test` reports "1 test passed successfully."
- [ ] `dgt new --flat tmp/bar && cd tmp/bar && dgt test` works (unit-tests.dg in `src/`)
- [ ] `dgt test -- <extra dgdebug args>` passes args through

🤖 Generated with [Claude Code](https://claude.com/claude-code)