### PR TITLE
Update ANSI styling to match what dgdebug produces

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -189,6 +189,10 @@ html {
   text-decoration: underline;
 }
 
+.ansi-fixed {
+  font-family: monospace, monospace;
+}
+
 .ansi-black {
   color: #1a1a1a;
 }

--- a/src/dialog_tool/skein/ui/ansi.clj
+++ b/src/dialog_tool/skein/ui/ansi.clj
@@ -53,14 +53,15 @@
 
 (defn- apply-sgr
   "Applies SGR codes to the current effects map.
-   Effects map: {:bold bool, :italic bool, :underline bool, :color \"name\" or nil}"
+   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\" or nil}"
   [effects codes]
   (reduce (fn [eff code]
             (cond
               (= code 0) {}
               (= code 1) (assoc eff :bold true)
-              (= code 3) (assoc eff :italic true)
-              (= code 4) (assoc eff :underline true)
+              (= code 4) (assoc eff :italic true)
+              (= code 7) (assoc eff :underline true)
+              (= code 50) (assoc eff :fixed true)
               (color-codes code) (assoc eff :color (color-names code))
               :else eff))
           effects
@@ -68,11 +69,12 @@
 
 (defn- effects->css-classes
   "Converts an effects map to a CSS class string."
-  [{:keys [bold italic underline color]}]
+  [{:keys [bold italic underline fixed color]}]
   (let [classes (cond-> []
                   bold (conj "ansi-bold")
                   italic (conj "ansi-italic")
                   underline (conj "ansi-underline")
+                  fixed (conj "ansi-fixed")
                   color (conj (str "ansi-" color)))]
     (when (seq classes)
       (string/join " " classes))))
@@ -109,19 +111,21 @@
   (cond
     (= code 0) nil
     (= code 1) "[B]"
-    (= code 3) "[I]"
-    (= code 4) "[U]"
+    (= code 4) "[I]"
+    (= code 7) "[U]"
+    (= code 50) "[TT]"
     (color-codes code) (str "[" (string/upper-case (color-names code)) "]")
     :else "[?]"))
 
 (defn- closing-markers
   "Returns closing pseudo-markers for all active effects (in reverse order).
-   Effects map: {:bold bool, :italic bool, :underline bool, :color \"name\", :unknown int}"
-  [{:keys [bold italic underline color unknown]}]
-  ;; Close in reverse order: unknown, color, underline, italic, bold
+   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\", :unknown int}"
+  [{:keys [bold italic underline fixed color unknown]}]
+  ;; Close in reverse order: unknown, color, fixed, underline, italic, bold
   (cond-> []
     (pos-int? unknown) (into (repeat unknown "[/?]"))
     color (conj (str "[/" (string/upper-case color) "]"))
+    fixed (conj "[/TT]")
     underline (conj "[/U]")
     italic (conj "[/I]")
     bold (conj "[/B]")))
@@ -154,8 +158,9 @@
                                                    (.append sb m))
                                                  (cond
                                                    (= code 1) (assoc eff :bold true)
-                                                   (= code 3) (assoc eff :italic true)
-                                                   (= code 4) (assoc eff :underline true)
+                                                   (= code 4) (assoc eff :italic true)
+                                                   (= code 7) (assoc eff :underline true)
+                                                   (= code 50) (assoc eff :fixed true)
                                                    (color-codes code) (assoc eff :color (color-names code))
                                                    :else (update eff :unknown (fnil inc 0))))
                                                effects


### PR DESCRIPTION
Fixes #54 (at least for italic, reverse, fixed; not handling fg and bg colors yet).