### PR TITLE
feat: process ANSI escape codes in dgdebug output properly

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -189,6 +189,10 @@ html {
   text-decoration: underline;
 }
 
+.ansi-fixed {
+  font-family: monospace, monospace;
+}
+
 .ansi-black {
   color: #1a1a1a;
 }

--- a/src/dialog_tool/skein/ui/ansi.clj
+++ b/src/dialog_tool/skein/ui/ansi.clj
@@ -119,9 +119,9 @@
 
 (defn- closing-markers
   "Returns closing pseudo-markers for all active effects (in reverse order).
-   Effects map: {:bold bool, :italic bool, :underline bool, :mono bool, :color \"name\", :unknown int}"
-  [{:keys [bold italic underline mono color unknown]}]
-  ;; Close in reverse order: unknown, color, mono, underline, italic, bold
+   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\", :unknown int}"
+  [{:keys [bold italic underline fixed color unknown]}]
+  ;; Close in reverse order: unknown, color, fixed, underline, italic, bold
   (cond-> []
     (pos-int? unknown) (into (repeat unknown "[/?]"))
     color     (conj (str "[/" (string/upper-case color) "]"))

--- a/src/dialog_tool/skein/ui/ansi.clj
+++ b/src/dialog_tool/skein/ui/ansi.clj
@@ -1,6 +1,26 @@
 (ns dialog-tool.skein.ui.ansi
   "Converts ANSI SGR escape codes to either styled Hiccup markup (for blessed output)
-   or visible pseudo-markers (for diff output where styling is overridden by diff spans)."
+   or visible pseudo-markers (for diff output where styling is overridden by diff spans).
+
+   SGR effects are tracked as a stack. Each push adds an entry {:tag \"B\" :css \"ansi-bold\"},
+   where :tag is the marker name (used in ansi->markers) and :css is the CSS class name
+   (used in ansi->hiccup; nil means no CSS contribution). A SGR reset (code 0) unwinds
+   the entire stack, emitting closing markers in reverse push order.
+
+   SGR 38;2;R;G;B sets a 24-bit RGB foreground color. Known RGB values map to named colors;
+   unknown values use the tag COLOR#RRGGBB with an inline CSS style.
+   SGR 39 (default foreground) closes the most recently pushed color entry.
+   
+   TODO: There are known problems with how this code parses output from dgdebug, and especially,
+   how it outputs CSS-styled markup when there are colors.
+   
+   Note that dgdebug renders italic text with the ANSI underlined code; we treat that
+   as italic ('[I]') and render to screen in italic.
+   
+   Likewise, dgdebug renders reverse video to indicate underlined.
+   
+   In addition, this is organized around how dgdebug outputs ANSI escapes and does not account
+   for differences in how frotz or other standard interpreters operate."
   (:require [clojure.string :as string]
             [dev.onionpancakes.chassis.core :as chassis]))
 
@@ -23,6 +43,18 @@
   "Set of SGR codes that represent foreground colors."
   (set (keys color-names)))
 
+(def ^:private known-rgb-colors
+  "Map from [r g b] triplet to color name, for dgdebug 24-bit color output."
+  ;; See https://github.com/Dialog-IF/dialog/blob/6107864a00b56c1f9de2a63a70d4f99ec2241d39/src/term_tty.c#L173
+  {[0x26 0x26 0x26] "black"
+   [0xdf 0x20 0x50] "red"
+   [0x18 0xaa 0x49] "green"
+   [0xb5 0xa9 0x29] "yellow"
+   [0x63 0x61 0xea] "blue"
+   [0xbf 0x1c 0xbf] "magenta"
+   [0x21 0xba 0xba] "cyan"
+   [0xf2 0xf2 0xf2] "white"})
+
 (defn- parse-sgr
   "Parses the parameter string from a CSI sequence into a seq of integers.
    An empty string is treated as [0] (reset)."
@@ -36,48 +68,111 @@
    Returns a vector of segments."
   [text]
   (let [matcher (re-matcher sgr-pattern text)]
-    (loop [pos 0
+    (loop [pos      0
            segments []]
       (if (.find matcher)
         (let [match-start (.start matcher)
-              match-end (.end matcher)
-              params (parse-sgr (.group matcher 1))
-              segments (if (> match-start pos)
-                         (conj segments [:text (subs text pos match-start)])
-                         segments)]
+              match-end   (.end matcher)
+              params      (parse-sgr (.group matcher 1))
+              segments    (if (> match-start pos)
+                            (conj segments [:text (subs text pos match-start)])
+                            segments)]
           (recur match-end (conj segments [:sgr params])))
         ;; No more matches; emit trailing text
         (if (< pos (count text))
           (conj segments [:text (subs text pos)])
           segments)))))
 
-(defn- apply-sgr
-  "Applies SGR codes to the current effects map.
-   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\" or nil}"
-  [effects codes]
-  (reduce (fn [eff code]
-            (cond
-              (= code 0)  {}
-              (= code 1)  (assoc eff :bold true)
-              (= code 4) (assoc eff :italic true)
-              (= code 7) (assoc eff :underline true)
-              (= code 50) (assoc eff :fixed true)
-              (color-codes code) (assoc eff :color (color-names code))
-              :else eff))
-          effects
-          codes))
+(defn- rgb-entry
+  "Creates a stack entry for a 24-bit RGB foreground color.
+   Looks up known colors first; falls back to a COLOR#RRGGBB tag with inline style."
+  [r g b]
+  (if-let [name (known-rgb-colors [r g b])]
+    {:tag (string/upper-case name) :css (str "ansi-" name) :color? true}
+    (let [hex (format "%02X%02X%02X" r g b)]
+      {:tag (str "#" hex) :css nil :style (str "color:#" (string/lower-case hex)) :color? true})))
 
-(defn- effects->css-classes
-  "Converts an effects map to a CSS class string."
-  [{:keys [bold italic underline fixed color]}]
-  (let [classes (cond-> []
-                  bold      (conj "ansi-bold")
-                  italic    (conj "ansi-italic")
-                  underline (conj "ansi-underline")
-                  fixed (conj "ansi-fixed")
-                  color     (conj (str "ansi-" color)))]
-    (when (seq classes)
-      (string/join " " classes))))
+(defn- code->entry
+  "Converts a single SGR code to a stack entry, or nil for codes handled elsewhere
+   (reset 0, default-foreground 39, or the multi-code RGB prefix 38)."
+  [code]
+  (cond
+    (= code 0) nil
+    (= code 1) {:tag "B" :css "ansi-bold"}
+    (= code 4) {:tag "I" :css "ansi-italic"}
+    (= code 7) {:tag "U" :css "ansi-underline"}
+    (= code 50) {:tag "TT" :css "ansi-fixed"}
+    (color-codes code) {:tag    (string/upper-case (color-names code))
+                        :css    (str "ansi-" (color-names code))
+                        :color? true}
+    :else {:tag (str code) :css nil}))
+
+(defn- sgr-actions
+  "Converts a SGR params vector to a sequence of actions.
+   Actions:
+     [:reset]        — clear the entire stack
+     [:pop-color]    — close and remove the most recent color entry
+     [:push entry]   — push a new entry onto the stack
+   Handles multi-code sequences: 38;2;R;G;B is consumed as one RGB push."
+  [codes]
+  (loop [[code & rest-codes :as remaining] codes
+         actions []]
+    (cond
+      (empty? remaining)
+      actions
+
+      (= code 0)
+      (recur rest-codes (conj actions [:reset]))
+
+      (= code 39)
+      (recur rest-codes (conj actions [:pop-color]))
+
+      ;; 38;2;R;G;B — 24-bit RGB foreground color
+      (and (= code 38)
+           (= (first rest-codes) 2)
+           (>= (count rest-codes) 4))
+      (let [[_ r g b & tail] rest-codes]
+        (recur tail (conj actions [:push (rgb-entry r g b)])))
+
+      :else
+      (recur rest-codes (conj actions [:push (code->entry code)])))))
+
+(defn- pop-color-entry
+  "Finds and removes the most recently pushed color entry (:color? true) from the stack.
+   Returns [new-stack popped-entry], or [stack nil] if no color entry is present."
+  [stack]
+  (let [idx (reduce (fn [found i]
+                      (if (:color? (nth stack i)) i found))
+                    nil
+                    (range (count stack)))]
+    (if idx
+      [(into (subvec stack 0 idx) (subvec stack (inc idx)))
+       (nth stack idx)]
+      [stack nil])))
+
+(defn- apply-actions
+  "Applies a sequence of sgr-actions to the stack. Returns the updated stack.
+   (Used by ansi->hiccup; ansi->markers handles actions inline to interleave marker output.)"
+  [stack actions]
+  (reduce (fn [s [action entry]]
+            (case action
+              :reset []
+              :pop-color (first (pop-color-entry s))
+              :push (if entry (conj s entry) s)))
+          stack
+          actions))
+
+(defn- stack->span-attrs
+  "Derives a hiccup attrs map from the current stack.
+   Combines CSS classes (from :css) and inline style (from :style entries).
+   Returns nil when the stack contributes no visible styling."
+  [stack]
+  (let [classes (->> stack (keep :css) distinct (string/join " ") not-empty)
+        style   (->> stack (keep :style) (string/join ";") not-empty)]
+    (when (or classes style)
+      (cond-> {}
+        classes (assoc :class classes)
+        style (assoc :style style)))))
 
 (defn ansi->hiccup
   "Converts text with ANSI SGR escape codes to Hiccup markup with styled spans.
@@ -89,89 +184,73 @@
     :else
     (let [segments (parse-segments text)]
       (loop [remaining segments
-             effects {}
-             result ^::chassis/content []]
+             stack     []
+             result    ^::chassis/content []]
         (if-let [[seg-type seg-value] (first remaining)]
           (case seg-type
             :sgr (recur (rest remaining)
-                        (apply-sgr effects seg-value)
+                        (apply-actions stack (sgr-actions seg-value))
                         result)
-            :text (let [classes (effects->css-classes effects)]
+            :text (let [attrs (stack->span-attrs stack)]
                     (recur (rest remaining)
-                           effects
+                           stack
                            (conj result
-                                 (if classes
-                                   [:span {:class classes} seg-value]
+                                 (if attrs
+                                   [:span attrs seg-value]
                                    seg-value)))))
           result)))))
 
-(defn- opening-marker
-  "Returns the opening pseudo-marker for an SGR code, or nil for reset (0)."
-  [code]
-  (cond
-    (= code 0)  nil
-    (= code 1)  "[B]"
-    (= code 4) "[I]"
-    (= code 7) "[U]"
-    (= code 50) "[TT]"
-    (color-codes code) (str "[" (string/upper-case (color-names code)) "]")
-    :else "[?]"))
-
-(defn- closing-markers
-  "Returns closing pseudo-markers for all active effects (in reverse order).
-   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\", :unknown int}"
-  [{:keys [bold italic underline fixed color unknown]}]
-  ;; Close in reverse order: unknown, color, fixed, underline, italic, bold
-  (cond-> []
-    (pos-int? unknown) (into (repeat unknown "[/?]"))
-    color     (conj (str "[/" (string/upper-case color) "]"))
-    fixed (conj "[/TT]")
-    underline (conj "[/U]")
-    italic    (conj "[/I]")
-    bold      (conj "[/B]")))
+(defn- closing-tags
+  "Returns closing pseudo-marker strings for all entries in the stack, in reverse push order."
+  [stack]
+  (map (fn [{:keys [tag]}] (str "[/" tag "]"))
+       (reverse stack)))
 
 (defn ansi->markers
   "Converts text with ANSI SGR escape codes to plain text with visible pseudo-markers.
    Used for diff output where ANSI styling would be overridden by diff spans.
-   Unrecognized SGR codes are represented as [?]."
+   Unrecognized SGR codes use the numeric code as the tag name."
   [text]
   (cond
     (nil? text) nil
     (not (string/includes? text "\u001b")) text
     :else
     (let [segments (parse-segments text)
-          sb (StringBuilder.)]
+          sb       (StringBuilder.)]
       (loop [remaining segments
-             effects {}]
+             stack     []]
         (if-let [[seg-type seg-value] (first remaining)]
           (case seg-type
-            :sgr (let [codes seg-value]
-                   (if (and (= 1 (count codes)) (= 0 (first codes)))
-                     ;; Reset: emit closing markers for all active effects
-                     (do
-                       (doseq [marker (closing-markers effects)]
-                         (.append sb marker))
-                       (recur (rest remaining) {}))
-                     ;; Non-reset: emit opening markers
-                     (let [new-effects (reduce (fn [eff code]
-                                                 (when-let [m (opening-marker code)]
-                                                   (.append sb m))
-                                                 (cond
-                                                   (= code 1)  (assoc eff :bold true)
-                                                   (= code 4) (assoc eff :italic true)
-                                                   (= code 7) (assoc eff :underline true)
-                                                   (= code 50) (assoc eff :fixed true)
-                                                   (color-codes code) (assoc eff :color (color-names code))
-                                                   :else (update eff :unknown (fnil inc 0))))
-                                               effects
-                                               codes)]
-                       (recur (rest remaining) new-effects))))
-            :text (do
-                    (.append sb seg-value)
-                    (recur (rest remaining) effects)))
+            :sgr
+            (let [new-stack
+                  (reduce (fn [s [action entry]]
+                            (case action
+                              :reset
+                              (do
+                                (doseq [marker (closing-tags s)]
+                                  (.append sb marker))
+                                [])
+                              :pop-color
+                              (let [[s' popped] (pop-color-entry s)]
+                                (when popped
+                                  (.append sb (str "[/" (:tag popped) "]")))
+                                s')
+                              :push
+                              (if entry
+                                (do
+                                  (.append sb (str "[" (:tag entry) "]"))
+                                  (conj s entry))
+                                s)))
+                          stack
+                          (sgr-actions seg-value))]
+              (recur (rest remaining) new-stack))
+            :text
+            (do
+              (.append sb seg-value)
+              (recur (rest remaining) stack)))
           ;; End of segments: close any remaining effects
           (do
-            (doseq [marker (closing-markers effects)]
+            (doseq [marker (closing-tags stack)]
               (.append sb marker))
             (.toString sb)))))))
 

--- a/src/dialog_tool/skein/ui/ansi.clj
+++ b/src/dialog_tool/skein/ui/ansi.clj
@@ -53,14 +53,15 @@
 
 (defn- apply-sgr
   "Applies SGR codes to the current effects map.
-   Effects map: {:bold bool, :italic bool, :underline bool, :color \"name\" or nil}"
+   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\" or nil}"
   [effects codes]
   (reduce (fn [eff code]
             (cond
               (= code 0) {}
               (= code 1) (assoc eff :bold true)
-              (= code 3) (assoc eff :italic true)
-              (= code 4) (assoc eff :underline true)
+              (= code 4) (assoc eff :italic true)
+              (= code 7) (assoc eff :underline true)
+              (= code 50) (assoc eff :fixed true)
               (color-codes code) (assoc eff :color (color-names code))
               :else eff))
           effects
@@ -68,11 +69,12 @@
 
 (defn- effects->css-classes
   "Converts an effects map to a CSS class string."
-  [{:keys [bold italic underline color]}]
+  [{:keys [bold italic underline fixed color]}]
   (let [classes (cond-> []
                   bold (conj "ansi-bold")
                   italic (conj "ansi-italic")
                   underline (conj "ansi-underline")
+                  fixed (conj "ansi-fixed")
                   color (conj (str "ansi-" color)))]
     (when (seq classes)
       (string/join " " classes))))
@@ -109,19 +111,21 @@
   (cond
     (= code 0) nil
     (= code 1) "[B]"
-    (= code 3) "[I]"
-    (= code 4) "[U]"
+    (= code 4) "[I]"
+    (= code 7) "[U]"
+    (= code 50) "[TT]"
     (color-codes code) (str "[" (string/upper-case (color-names code)) "]")
     :else "[?]"))
 
 (defn- closing-markers
   "Returns closing pseudo-markers for all active effects (in reverse order).
-   Effects map: {:bold bool, :italic bool, :underline bool, :color \"name\", :unknown int}"
-  [{:keys [bold italic underline color unknown]}]
-  ;; Close in reverse order: unknown, color, underline, italic, bold
+   Effects map: {:bold bool, :italic bool, :underline bool, :fixed bool, :color \"name\", :unknown int}"
+  [{:keys [bold italic underline fixed color unknown]}]
+  ;; Close in reverse order: unknown, color, fixed, underline, italic, bold
   (cond-> []
     (pos-int? unknown) (into (repeat unknown "[/?]"))
     color (conj (str "[/" (string/upper-case color) "]"))
+    fixed (conj "[/TT]")
     underline (conj "[/U]")
     italic (conj "[/I]")
     bold (conj "[/B]")))
@@ -154,8 +158,9 @@
                                                    (.append sb m))
                                                  (cond
                                                    (= code 1) (assoc eff :bold true)
-                                                   (= code 3) (assoc eff :italic true)
-                                                   (= code 4) (assoc eff :underline true)
+                                                   (= code 4) (assoc eff :italic true)
+                                                   (= code 7) (assoc eff :underline true)
+                                                   (= code 50) (assoc eff :fixed true)
                                                    (color-codes code) (assoc eff :color (color-names code))
                                                    :else (update eff :unknown (fnil inc 0))))
                                                effects

--- a/test/dialog_tool/skein/ui/ansi_test.clj
+++ b/test/dialog_tool/skein/ui/ansi_test.clj
@@ -11,9 +11,10 @@
 
 (def RESET (sgr 0))
 (def BOLD (sgr 1))
-(def ITALIC (sgr 3))
-(def UNDERLINE (sgr 4))
-(def MONO (sgr 50))
+;; TODO: Should be engine aware (unless dfrotz does the same thing)
+(def UNDERLINE (sgr 4))                                     ; ANSI underline is dgdebug's way of showing italic
+(def REVERSE (sgr 7))                                       ; ANSI reverse is dgdebug's way of showing underline
+(def TT (sgr 50))
 (def RED (sgr 31))
 (def BLUE (sgr 34))
 
@@ -31,11 +32,11 @@
 
 (deftest hiccup-italic
   (is (= [[:span {:class "ansi-italic"} "hello"]]
-         (ansi->hiccup (str ITALIC "hello")))))
+         (ansi->hiccup (str UNDERLINE "hello")))))
 
 (deftest hiccup-underline
   (is (= [[:span {:class "ansi-underline"} "hello"]]
-         (ansi->hiccup (str UNDERLINE "hello")))))
+         (ansi->hiccup (str REVERSE "hello")))))
 
 (deftest hiccup-color
   (is (= [[:span {:class "ansi-red"} "error"]]
@@ -63,13 +64,13 @@
     (is (= [[:span {:class "ansi-bold ansi-blue"} "both"]]
            (ansi->hiccup (str ESC "[1;34m" "both"))))))
 
-(deftest hiccup-mono
-  (is (= [[:span {:class "ansi-mono"} "output"]]
-         (ansi->hiccup (str MONO "output")))))
+(deftest hiccup-fixed
+  (is (= [[:span {:class "ansi-fixed"} "output"]]
+         (ansi->hiccup (str TT "output")))))
 
-(deftest hiccup-mono-and-bold
-  (is (= [[:span {:class "ansi-bold ansi-mono"} "output"]]
-         (ansi->hiccup (str BOLD MONO "output")))))
+(deftest hiccup-fixed-and-bold
+  (is (= [[:span {:class "ansi-bold ansi-fixed"} "output"]]
+         (ansi->hiccup (str BOLD TT "output")))))
 
 (deftest hiccup-bare-esc-bracket-m-is-reset
   (testing "ESC[m with no params is treated as reset"
@@ -90,11 +91,11 @@
 
 (deftest markers-italic
   (is (= "[I]hello[/I]"
-         (ansi->markers (str ITALIC "hello" RESET)))))
+         (ansi->markers (str UNDERLINE "hello" RESET)))))
 
 (deftest markers-underline
   (is (= "[U]hello[/U]"
-         (ansi->markers (str UNDERLINE "hello" RESET)))))
+         (ansi->markers (str REVERSE "hello" RESET)))))
 
 (deftest markers-color
   (is (= "[RED]error[/RED]"
@@ -124,13 +125,13 @@
     (is (= "[B][RED]alert[/RED][/B]"
            (ansi->markers (str ESC "[1;31m" "alert" RESET))))))
 
-(deftest markers-mono
-  (is (= "[MONO]output[/MONO]"
-         (ansi->markers (str MONO "output" RESET)))))
+(deftest markers-fixed
+  (is (= "[TT]output[/TT]"
+         (ansi->markers (str TT "output" RESET)))))
 
-(deftest markers-mono-unclosed
-  (is (= "[MONO]output[/MONO]"
-         (ansi->markers (str MONO "output")))))
+(deftest markers-fixed-unclosed
+  (is (= "[TT]output[/TT]"
+         (ansi->markers (str TT "output")))))
 
 (deftest markers-unrecognized-sgr-code
   (testing "unrecognized SGR codes are represented as [?] / [/?]"
@@ -142,4 +143,4 @@
 
 (deftest strip-ansi-removes-sgr
   (is (= "hello world"
-         (strip-ansi (str BOLD "hello" RESET " " UNDERLINE "world" RESET)))))
+         (strip-ansi (str BOLD "hello" RESET " " REVERSE "world" RESET)))))

--- a/test/dialog_tool/skein/ui/ansi_test.clj
+++ b/test/dialog_tool/skein/ui/ansi_test.clj
@@ -17,6 +17,8 @@
 (def TT (sgr 50))
 (def RED (sgr 31))
 (def BLUE (sgr 34))
+(def DEFAULT-FG (sgr 39))
+(def RGB-UNKNOWN (sgr 38 2 0xaa 0xbb 0xcc))                         ; unknown color, uses COLOR# tag
 
 ;; --- ansi->hiccup ---
 
@@ -55,9 +57,9 @@
          (ansi->hiccup (str "before " RED "red" RESET " after")))))
 
 (deftest hiccup-color-change
-  (testing "changing color replaces previous color"
+  (testing "changing color after reset starts fresh"
     (is (= [[:span {:class "ansi-red"} "red"] [:span {:class "ansi-blue"} "blue"]]
-           (ansi->hiccup (str RED "red" BLUE "blue"))))))
+           (ansi->hiccup (str RED "red" RESET BLUE "blue"))))))
 
 (deftest hiccup-combined-sgr-params
   (testing "CSI 1;34 m sets bold+blue in one sequence"
@@ -76,6 +78,16 @@
   (testing "ESC[m with no params is treated as reset"
     (is (= [[:span {:class "ansi-bold"} "bold"] " normal"]
            (ansi->hiccup (str BOLD "bold" ESC "[m" " normal"))))))
+
+(deftest hiccup-rgb-unknown-color
+  (testing "38;2;R;G;B with unknown color uses inline style"
+    (is (= [[:span {:style "color:#aabbcc"} "pink"]]
+           (ansi->hiccup (str RGB-UNKNOWN "pink"))))))
+
+(deftest hiccup-rgb-default-fg-closes-color
+  (testing "SGR 39 removes the color from the stack"
+    (is (= [[:span {:style "color:#aabbcc"} "pink"] " normal"]
+           (ansi->hiccup (str RGB-UNKNOWN "pink" DEFAULT-FG " normal"))))))
 
 ;; --- ansi->markers ---
 
@@ -134,10 +146,25 @@
          (ansi->markers (str TT "output")))))
 
 (deftest markers-unrecognized-sgr-code
-  (testing "unrecognized SGR codes are represented as [?] / [/?]"
+  (testing "unrecognized SGR codes use the numeric code as the tag"
     ;; SGR 6 is "rapid blink", not something we support
-    (is (= "[?]hello[/?]"
+    (is (= "[6]hello[/6]"
            (ansi->markers (str (sgr 6) "hello" RESET))))))
+
+(deftest markers-rgb-unknown-color
+  (testing "38;2;R;G;B with unknown color uses COLOR#RRGGBB tag"
+    (is (= "[#AABBCC]pink[/#AABBCC]"
+           (ansi->markers (str RGB-UNKNOWN "pink" RESET))))))
+
+(deftest markers-default-fg-closes-color
+  (testing "SGR 39 closes the most recent color entry"
+    (is (= "[RED]bold-red[/RED] plain"
+           (ansi->markers (str RED "bold-red" DEFAULT-FG " plain"))))))
+
+(deftest markers-default-fg-with-bold-underneath
+  (testing "SGR 39 closes only the color, leaving bold active"
+    (is (= "[B][RED]bold-red[/RED]still-bold[/B]"
+           (ansi->markers (str BOLD RED "bold-red" DEFAULT-FG "still-bold" RESET))))))
 
 ;; --- strip-ansi ---
 


### PR DESCRIPTION
Though this is still a work in process.  It does a better job than before, especially with RGB encoded fonts.

This replces #55 

Fixes #54 