### PR TITLE
Accessibility improvements and shutdown fix

### DIFF
--- a/public/style.css
+++ b/public/style.css
@@ -46,6 +46,11 @@ html {
   -webkit-mask-image: url('/icons/exclamation-triangle.svg');
 }
 
+.icon-error {
+  mask-image: url('/icons/x-circle-solid.svg');
+  -webkit-mask-image: url('/icons/x-circle-solid.svg');
+}
+
 .icon-undo {
   mask-image: url('/icons/arrow-uturn-left.svg');
   -webkit-mask-image: url('/icons/arrow-uturn-left.svg');

--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -444,6 +444,10 @@ let networkErrorShown = false;
 
 function showNetworkErrorModal() {
   if (networkErrorShown) return;
+  // Suppress if the server already rendered the intentional shutdown page.
+  // The closing-page DOM update arrives via SSE before the reconnect failure
+  // fires this function, so this check reliably catches intentional shutdowns.
+  if (document.getElementById('skein-shutdown')) return;
   networkErrorShown = true;
 
   // #modal-container only exists in the DOM when a server-rendered modal is open.

--- a/src/dialog_tool/skein/ui/actions.clj
+++ b/src/dialog_tool/skein/ui/actions.clj
@@ -246,7 +246,8 @@
                              session/capture-undo
                              (assoc-in [:last-jump status] next-id)
                              (session/select-knot next-id)
-                             (session/set-active-knot-id next-id)))))))
+                             (session/set-active-knot-id next-id)
+                             js/navigate-to-active-knot!))))))
 
 (defn jump-to-label
   [id]

--- a/src/dialog_tool/skein/ui/app.clj
+++ b/src/dialog_tool/skein/ui/app.clj
@@ -54,7 +54,7 @@
      [:label.input.input-sm.input-bordered.flex.items-center.gap-2.w-full.tooltip.tooltip-bottom.search-expand-label
       {:data-accel "f"
        :data-label "Search"}
-      [:div.icon.w-4.h-4.icon-search]
+      [:div.icon.w-4.h-4.icon-search {:aria-hidden "true"}]
       [:input#search-input.grow
        {:type "text"
         :placeholder "Search knots…"
@@ -94,11 +94,12 @@
   [attrs icon label]
   (let [extra-class (:class attrs)
         attrs' (into {} (remove (comp nil? val) (dissoc attrs :class)))]
-    [:div (assoc attrs'
-                 :class (classes "btn btn-primary tooltip tooltip-bottom" extra-class)
-                 :data-label label
-                 :data-preserve-attr "data-tip")
-     [:div.icon {:class icon}]
+    [:button (assoc attrs'
+                    :type "button"
+                    :class (classes "btn btn-primary tooltip tooltip-bottom" extra-class)
+                    :data-label label
+                    :data-preserve-attr "data-tip")
+     [:div.icon {:class icon :aria-hidden "true"}]
      [:span.hidden.lg:inline label]]))
 
 (defn- simple-action
@@ -125,19 +126,31 @@
       [:div.self-center.truncate.text-xl.font-semibold.shrink.min-w-0
        skein-path]
       [:div.join.shrink-0.mx-auto
-       [:div.bg-success.text-success-content.p-2.font-semibold.rounded-l-lg ok]
-       [:div.bg-warning.text-warning-content.p-2.font-semibold
-        (when (pos? new)
-          {:class "cursor-pointer"
+       [:div.bg-success.text-success-content.p-2.font-semibold.rounded-l-lg
+        {:aria-label (str ok " ok knots")}
+        ok]
+       (if (pos? new)
+         [:div.bg-warning.text-warning-content.p-2.font-semibold.cursor-pointer
+          {:role          "button"
+           :tabindex      "0"
+           :aria-label    (str new " new knots")
            :data-on:click (h/action {:as "seek-new"}
-                                    (actions/seek-status :new))})
-        new]
-       [:div.bg-error.text-error-content.p-2.font-semibold.rounded-r-lg
-        (when (pos? error)
-          {:class "cursor-pointer"
+                                    (actions/seek-status :new))}
+          new]
+         [:div.bg-warning.text-warning-content.p-2.font-semibold
+          {:aria-label (str new " new knots")}
+          new])
+       (if (pos? error)
+         [:div.bg-error.text-error-content.p-2.font-semibold.rounded-r-lg.cursor-pointer
+          {:role          "button"
+           :tabindex      "0"
+           :aria-label    (str error " error knots")
            :data-on:click (h/action {:as "seek-error"}
-                                    (actions/seek-status :error))})
-        error]]
+                                    (actions/seek-status :error))}
+          error]
+         [:div.bg-error.text-error-content.p-2.font-semibold.rounded-r-lg
+          {:aria-label (str error " error knots")}
+          error])]
       [:div.flex.items-center.gap-1.shrink-0.ml-auto
               (dropdown/dropdown {:disabled              (<= (count labeled-knots) 1)
                                   :label                 (list [:div.icon.icon-jump] [:span.hidden.lg:inline "Jump"])
@@ -173,9 +186,10 @@
                     :data-tip "Reload"
                     :disabled (not can-reload?)}
                    "icon-reload" "Reload")
-       [:div.btn.btn-primary {:data-on:click (h/action {:as "quit"}
-                                                       (actions/quit))}
-        [:div.icon.icon-quit] [:span.hidden.lg:inline "Quit"]]]]]))
+       [:button.btn.btn-primary {:type "button"
+                                  :data-on:click (h/action {:as "quit"}
+                                                           (actions/quit))}
+        [:div.icon.icon-quit {:aria-hidden "true"}] [:span.hidden.lg:inline "Quit"]]]]]))
 
 (def ^:private status->border-class
   {:ok "border-base-300"
@@ -225,10 +239,10 @@
      ;; Active-knot marker + status icon: sit in the left gutter, outside the knot content
      [:div.w-5.shrink-0.flex.flex-col.items-center.justify-start.pt-2.gap-1.pr-1
       (when active?
-        [:div.icon.icon-arrow-right {:title "Selected"}])
+        [:div.icon.icon-arrow-right {:role "img" :aria-label "Selected"}])
       (case status
-        :new   [:div.icon.icon-warning.w-4.h-4 {:title "New knot"}]
-        :error [:div.icon.icon-error.w-4.h-4 {:title "Error knot"}]
+        :new   [:div.icon.icon-warning.w-4.h-4 {:role "img" :aria-label "New knot"}]
+        :error [:div.icon.icon-error.w-4.h-4   {:role "img" :aria-label "Error knot"}]
         nil)]
      [:div
       {:class (classes "border-x-8 grow cursor-pointer"
@@ -244,7 +258,7 @@
        (when (or locked label)
          [:div.float-right.flex.flex-row.items-center.gap-1.pl-2.pb-1
           (when locked
-            [:div.icon.icon-lock {:title "Locked"}])
+            [:div.icon.icon-lock {:role "img" :aria-label "Locked"}])
           (when label
             [:span.font-bold.bg-neutral.text-neutral-content.px-1.py-0.5.rounded.text-sm
              label])])
@@ -256,17 +270,17 @@
 
 (defn- toolbar-btn
   "Renders a single operations-toolbar button.
-  For accel buttons pass :data-label — the plugin reads it to build data-tip (label
-  + shortcut). For non-accel buttons pass :data-tip directly.
+  Pass :data-label — the accel plugin reads it to build data-tip (label + shortcut).
   data-preserve-attr ensures Datastar's morph never removes the plugin-written data-tip.
   Accepts an optional :tooltip-dir key (default \"bottom\") to control placement."
   [attrs icon]
   (let [tooltip-dir (get attrs :tooltip-dir "bottom")
         attrs' (into {} (remove (comp nil? val) (dissoc attrs :tooltip-dir)))]
-    [:div (assoc attrs'
-                 :class (classes "btn btn-xs btn-primary tooltip" (str "tooltip-" tooltip-dir))
-                 :data-preserve-attr "data-tip")
-     [:div.icon.w-4.h-4 {:class icon}]]))
+    [:button (assoc attrs'
+                    :type "button"
+                    :class (classes "btn btn-xs btn-primary tooltip" (str "tooltip-" tooltip-dir))
+                    :data-preserve-attr "data-tip")
+     [:div.icon.w-4.h-4 {:class icon :aria-hidden "true"}]]))
 
 (defn- render-operations-toolbar
   [*session selected-knots]
@@ -413,7 +427,7 @@
                    "icon-delete")
       (let [disabled? (or root? (nil? children))]
         (toolbar-btn {:disabled disabled?
-                      :data-tip "Splice Out"
+                      :data-label "Splice Out"
                       :data-on:click (when-not disabled?
                                        (h/action {:as "splice-out"}
                                                  (actions/split-out id)))}

--- a/src/dialog_tool/skein/ui/app.clj
+++ b/src/dialog_tool/skein/ui/app.clj
@@ -488,7 +488,7 @@
      (cond
        closing?
         ;; Server is shutting down — show close message
-       [:div.flex.items-center.justify-center.h-screen
+       [:div#skein-shutdown.flex.items-center.justify-center.h-screen
         [:div.text-center
          [:h2.text-2xl.font-semibold.text-base-content.mb-4 "Skein Shutdown"]
          [:p.text-base-content.opacity-70 "You may close this window now."]]]

--- a/src/dialog_tool/skein/ui/app.clj
+++ b/src/dialog_tool/skein/ui/app.clj
@@ -222,10 +222,14 @@
     [:div.flex.flex-row
      {:id (str "knot-" id)
       :data-knot-id (str id)}
-     ;; Active-knot marker: sits in the left gutter, outside the knot content
-     [:div.w-5.shrink-0.flex.items-start.justify-center.pt-2
+     ;; Active-knot marker + status icon: sit in the left gutter, outside the knot content
+     [:div.w-5.shrink-0.flex.flex-col.items-center.justify-start.pt-2.gap-1.pr-1
       (when active?
-        [:div.icon.icon-arrow-right {:title "Selected"}])]
+        [:div.icon.icon-arrow-right {:title "Selected"}])
+      (case status
+        :new   [:div.icon.icon-warning.w-4.h-4 {:title "New knot"}]
+        :error [:div.icon.icon-error.w-4.h-4 {:title "Error knot"}]
+        nil)]
      [:div
       {:class (classes "border-x-8 grow cursor-pointer"
                        (when active? "border-l-primary")

--- a/src/dialog_tool/skein/ui/components/dropdown.clj
+++ b/src/dialog_tool/skein/ui/components/dropdown.clj
@@ -17,17 +17,19 @@
   (let [id          (str "dd-" (random-uuid))
         extra-attrs (dissoc opts :label :disabled :button-class)]
     [:div
-     [:button (merge {:class           (classes "btn m-0" button-class)
-                      :disabled        disabled
-                      :popovertarget   id
+     [:button (merge {:class               (classes "btn m-0" button-class)
+                      :disabled            disabled
+                      :aria-haspopup       "menu"
+                      :popovertarget       id
                       :data-on:click__stop "return"}
                      extra-attrs)
       label]
      [:ul.menu.bg-base-100.rounded-box.p-2.w-96.overflow-y-auto.flex-nowrap
-      {:id id
-       :popover "auto"
-       :class "shadow-xl/30 max-h-[30rem]"
-       :data-on:toggle "sk.positionDropdown(el, evt)"
+      {:id              id
+       :role            "menu"
+       :popover         "auto"
+       :class           "shadow-xl/30 max-h-[30rem]"
+       :data-on:toggle  "sk.positionDropdown(el, evt)"
        :data-on:click   "el.hidePopover()"
        :data-on:keydown "sk.navigateDropdown(el, evt)"}
       items]]))
@@ -48,7 +50,7 @@
                                :class bg-class
                                :role "menuitem"
                                :tabindex "-1"}
-                              (dissoc options :disabled))
+                              (dissoc options :disabled :bg-class))
                  disabled (assoc :disabled true))]
      [:li
       {:class (when disabled "menu-disabled")}

--- a/src/dialog_tool/skein/ui/components/modal.clj
+++ b/src/dialog_tool/skein/ui/components/modal.clj
@@ -63,17 +63,21 @@
     [:div#modal-container
      {:class "fixed inset-0 z-50 flex items-center justify-center bg-black/40 backdrop-grayscale"}
      [:div.bg-base-100.rounded-lg.shadow-xl.max-w-full.min-w-md.mx-4
-      (cond-> {:data-on:click__stop "return"
+      (cond-> {:role                "dialog"
+               :aria-modal          "true"
+               :aria-labelledby     "modal-title"
+               :data-on:click__stop "return"
                :tabindex            "-1"
                :data-init           "el.focus()"}
         keydown (assoc :data-on:keydown keydown))
       ;; Header
       [:div.px-6.py-4.border-b.border-base-200
-       [:h3.text-lg.font-medium.text-base-content title]]
+       [:h3#modal-title.text-lg.font-medium.text-base-content title]]
       ;; Error message (if present)
       (when error
         [:div.px-6.pt-4
          [:div.alert.alert-error.text-sm
+          {:role "alert" :aria-live "assertive"}
           [:p.text-sm error]]])
       ;; Body
       [:div.px-6.py-4

--- a/src/dialog_tool/skein/ui/components/new_command.clj
+++ b/src/dialog_tool/skein/ui/components/new_command.clj
@@ -28,10 +28,11 @@
   (let [command-signal (h/local-signal :new-command "")]
     [:div.mt-4.mb-8
      [:div.flex.items-center.gap-2
-      [:span.text-gray-400 ">"]
+      [:span.text-gray-400 {:aria-hidden "true"} ">"]
       [:input#new-command-input
        {:type        "text"
         :name        "command"
+        :aria-label  "Enter command"
         :placeholder "Enter command..."
         :class       "flex-1 rounded-md border-base-300 shadow-sm focus:border-primary focus:ring-primary sm:text-sm p-2 border"
         :data-bind   (:name command-signal)

--- a/src/dialog_tool/skein/ui/modals.clj
+++ b/src/dialog_tool/skein/ui/modals.clj
@@ -36,7 +36,8 @@
        [:div.flex.justify-end.gap-2.mt-2
         (modal/cancel-button)
         [:button.btn.btn-primary
-         {:data-on:click (h/action {:as "source-error:replay-all"}
+         {:type          "button"
+          :data-on:click (h/action {:as "source-error:replay-all"}
                                    (replay-all))}
          "Replay All"]]])))
 
@@ -199,7 +200,9 @@
             [:span.text-sm.text-base-content.opacity-70 label])]
          ;; Progress bar
          [:progress.progress.progress-primary.w-full
-          {:value current :max total}]]))))
+          {:value     current
+           :max       total
+           :aria-label operation}]]))))
 
 (defn dynamic-state
   "Renders a modal dialog displaying the dynamic response."
@@ -264,7 +267,8 @@
                           :submit dismiss-modal})]
        ;; Hidden popup for source preview on hover (positioned by JS)
        [:div#source-preview-popup.hidden.fixed.z-50.bg-white.text-black.border.border-gray-200.rounded-lg.shadow-xl.overflow-hidden
-        {:class "max-w-[80vw]"}]])))
+        {:class       "max-w-[80vw]"
+         :aria-hidden "true"}]])))
 
 (defn render-modal
   "Renders the appropriate modal based on the global :modal cursor."

--- a/src/dialog_tool/skein/ui/tree_pane.clj
+++ b/src/dialog_tool/skein/ui/tree_pane.clj
@@ -73,6 +73,10 @@
        :title             command
        :data-on:click     (h/action {:as "tree-node-click"}
                                     (actions/select-tree-node id))}
+      (case status
+        :new   [:div.icon.icon-warning.w-3.h-3.shrink-0 {:title "New knot"}]
+        :error [:div.icon.icon-error.w-3.h-3.shrink-0 {:title "Error knot"}]
+        nil)
       (when locked
         [:div.icon.icon-lock.w-3.h-3.shrink-0 {:title "Locked"}])
       (when label

--- a/src/dialog_tool/skein/ui/tree_pane.clj
+++ b/src/dialog_tool/skein/ui/tree_pane.clj
@@ -63,29 +63,32 @@
         expanded?         (contains? expanded-ids id)
         active?           (= id (get-in tree [:active-knot-id]))]
     [:div.flex.flex-col.items-center.gap-1
-     [:div
-      {:class             (classes "flex flex-row items-center gap-1 px-2 py-1 rounded-lg border-2"
+     [:button
+      {:type              "button"
+       :class             (classes "flex flex-row items-center gap-1 px-2 py-1 rounded-lg border-2"
                                    "cursor-pointer select-none text-sm min-w-16 max-w-48"
                                    (node-color-class status descendant-status on-spine? active?)
                                    (if active? "border-primary" "border-transparent"))
        :data-tree-node-id (str id)
        :data-parent-id    (some-> parent-id str)
-       :title             command
+       :aria-label        (str command (case status :new " (new)" :error " (error)" ""))
+       :aria-pressed      (str active?)
        :data-on:click     (h/action {:as "tree-node-click"}
                                     (actions/select-tree-node id))}
       (case status
-        :new   [:div.icon.icon-warning.w-3.h-3.shrink-0 {:title "New knot"}]
-        :error [:div.icon.icon-error.w-3.h-3.shrink-0 {:title "Error knot"}]
+        :new   [:div.icon.icon-warning.w-3.h-3.shrink-0 {:aria-hidden "true"}]
+        :error [:div.icon.icon-error.w-3.h-3.shrink-0   {:aria-hidden "true"}]
         nil)
       (when locked
-        [:div.icon.icon-lock.w-3.h-3.shrink-0 {:title "Locked"}])
+        [:div.icon.icon-lock.w-3.h-3.shrink-0 {:aria-hidden "true"}])
       (when label
         [:span.text-xs.font-bold.bg-neutral.text-neutral-content.px-1.rounded.shrink-0 label])
       [:span.truncate.font-mono.text-xs (truncate command 22)]]
      (when has-kids?
        [:button
         {:class         "btn btn-xs btn-ghost py-0 px-1 min-h-0 h-5 leading-none"
-         :title         (if expanded? "Collapse" "Expand")
+         :aria-label    (if expanded? "Collapse" "Expand")
+         :aria-expanded (str expanded?)
          :data-on:click (h/action {:as "toggle-tree-node"}
                                   (actions/toggle-tree-node id))}
         (if expanded? "\u25be" "\u25b8")])]))


### PR DESCRIPTION
## Summary

- Add warning/error icons to nav graph nodes and transcript gutter to supplement color-only status coding (new/error knots)
- Fix seek-status (clicking error/new count badges) not scrolling the transcript to the target knot
- Screen reader pass: `role=dialog`/`aria-modal`/`aria-labelledby` on modals, `role=img`/`aria-label` on status icons, `aria-hidden` on decorative icons, `div`→`button` for all toolbar/navbar/tree-node interactive elements, `aria-label` on count badges, `role=menu`/`aria-haspopup` on dropdown, `aria-label` on command input
- Suppress spurious "Network Error" modal after intentional quit — checks for `#skein-shutdown` in the DOM rather than relying on a server-sent script (which cannot be delivered after `shutdown-fn` kills the renderer)

🤖 Generated with [eca](https://eca.dev)