### PR TITLE
feat: drag-to-scroll on navigation graph background

### DIFF
--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -232,9 +232,8 @@ window.sk = {
 
   /**
    * Called once via data-init on #tree-pane.
-   * Draws arrows immediately, then watches for DOM changes (SSE patches that
-   * rebuild the tree) and redraws.  Disconnects before redrawing to avoid
-   * recursive MutationObserver triggers.
+   * - Draws SVG arrows immediately and keeps them redrawn on DOM / size changes.
+   * - Enables click-and-drag panning on the pane background.
    */
   initTreeGraph() {
     if (this._treeGraphReady) return;
@@ -242,8 +241,9 @@ window.sk = {
 
     const pane = document.getElementById('tree-pane');
     if (!pane) return;
+
+    // --- Arrow drawing ---
     // Defer initial draw until layout is complete so getBoundingClientRect is accurate.
-    // After drawing, scroll root into horizontal center so the tree is visible.
     requestAnimationFrame(() => this.drawTreeArrows());
     const self = this;
     const observer = new MutationObserver(() => {
@@ -261,6 +261,41 @@ window.sk = {
     // resize and the pane splitter being dragged (neither triggers a DOM mutation).
     new ResizeObserver(() => requestAnimationFrame(() => self.drawTreeArrows()))
       .observe(pane);
+
+    // --- Drag-to-scroll (pan) ---
+    // Clicking on the pane background and dragging scrolls the pane.
+    // Clicks that land on interactive descendants (buttons, links, etc.) are ignored.
+    let dragging = false;
+    let startX = 0;
+    let startY = 0;
+    let scrollX = 0;
+    let scrollY = 0;
+
+    pane.addEventListener('mousedown', (e) => {
+      if (e.button !== 0) return;
+      if (e.target.closest('button, a, input, select, textarea')) return;
+      dragging = true;
+      startX  = e.clientX;
+      startY  = e.clientY;
+      scrollX = pane.scrollLeft;
+      scrollY = pane.scrollTop;
+      pane.style.cursor = 'grabbing';
+      pane.style.userSelect = 'none';
+      e.preventDefault();
+    });
+
+    document.addEventListener('mousemove', (e) => {
+      if (!dragging) return;
+      pane.scrollLeft = scrollX - (e.clientX - startX);
+      pane.scrollTop  = scrollY - (e.clientY - startY);
+    });
+
+    document.addEventListener('mouseup', () => {
+      if (!dragging) return;
+      dragging = false;
+      pane.style.cursor = '';
+      pane.style.userSelect = '';
+    });
   },
 
   /**

--- a/src/dialog_tool/skein/ui/tree_pane.clj
+++ b/src/dialog_tool/skein/ui/tree_pane.clj
@@ -23,23 +23,23 @@
   based on descendant-status so problem knots are visible from their ancestors."
   [status descendant-status on-spine? active?]
   (case status
-    :new   (cond active?   "bg-warning text-warning-content"
-                 on-spine? "bg-warning/80 text-warning-content"
-                 :else     "bg-warning/40 text-warning-content")
-    :error (cond active?   "bg-error text-error-content"
+    :new (cond active? "bg-warning text-warning-content"
+               on-spine? "bg-warning/80 text-warning-content"
+               :else "bg-warning/40 text-warning-content")
+    :error (cond active? "bg-error text-error-content"
                  on-spine? "bg-error/80 text-error-content"
-                 :else     "bg-error/40 text-error-content")
+                 :else "bg-error/40 text-error-content")
     ;; Own status is :ok — tint by worst descendant status if any
     (case descendant-status
-      :error (cond active?   "bg-error/50 text-base-content"
+      :error (cond active? "bg-error/50 text-base-content"
                    on-spine? "bg-error/30 text-base-content"
-                   :else     "bg-error/20 text-base-content")
-      :new   (cond active?   "bg-warning/50 text-base-content"
-                   on-spine? "bg-warning/30 text-base-content"
-                   :else     "bg-warning/20 text-base-content")
-      (cond active?   "bg-primary text-primary-content"
+                   :else "bg-error/20 text-base-content")
+      :new (cond active? "bg-warning/50 text-base-content"
+                 on-spine? "bg-warning/30 text-base-content"
+                 :else "bg-warning/20 text-base-content")
+      (cond active? "bg-primary text-primary-content"
             on-spine? "bg-primary-content text-primary"
-            :else     "bg-neutral-content text-neutral"))))
+            :else "bg-neutral-content text-neutral"))))
 
 (defn- truncate
   "Truncates s to at most n chars, appending … if longer."
@@ -76,8 +76,8 @@
        :data-on:click     (h/action {:as "tree-node-click"}
                                     (actions/select-tree-node id))}
       (case status
-        :new   [:div.icon.icon-warning.w-3.h-3.shrink-0 {:aria-hidden "true"}]
-        :error [:div.icon.icon-error.w-3.h-3.shrink-0   {:aria-hidden "true"}]
+        :new [:div.icon.icon-warning.w-3.h-3.shrink-0 {:aria-hidden "true"}]
+        :error [:div.icon.icon-error.w-3.h-3.shrink-0 {:aria-hidden "true"}]
         nil)
       (when locked
         [:div.icon.icon-lock.w-3.h-3.shrink-0 {:aria-hidden "true"}])
@@ -121,11 +121,11 @@
   (let [session        @*session
         tree           (:tree session)
         active-knot-id (get-in tree [:active-knot-id])
-        spine-ids'   (into #{} (map :id (tree/selected-knots tree)))
-        expanded-ids (get tree :expanded-ids #{})]
+        spine-ids'     (into #{} (map :id (tree/selected-knots tree)))
+        expanded-ids   (get tree :expanded-ids #{})]
     [:div#tree-pane
-          {:class            "overflow-x-auto overflow-y-auto p-4 relative bg-base-200 h-full"
-      :data-active-knot         (str active-knot-id)
-      :data-init                "sk.initTreeGraph()"
-      :data-on:resize__window   "sk.drawTreeArrows()"}
+     {:class                  "overflow-x-auto overflow-y-auto p-4 relative bg-base-200 h-full cursor-grab"
+      :data-active-knot       (str active-knot-id)
+      :data-init              "sk.initTreeGraph()"
+      :data-on:resize__window "sk.drawTreeArrows()"}
      (render-subtree tree 0 spine-ids' expanded-ids)]))


### PR DESCRIPTION
- Clicking and dragging on the tree pane background now scrolls/pans the diagram
- `cursor-grab` on the pane background signals the interaction; switches to `cursor-grabbing` while dragging
- Pan logic lives inside `initTreeGraph()` — no separate function needed

🤖 Generated with [ECA](https://eca.dev) (nubank-anthropic/sonnet-4.6)