### PR TITLE
feat: FAB keyboard accelerator, tooltip, and panel navigation

### DIFF
--- a/resources/public/js/main.js
+++ b/resources/public/js/main.js
@@ -203,6 +203,112 @@ window.sk = {
   },
 
   /**
+   * Initialises the FAB settings panel.  Called once via data-init on #fab.
+   *
+   * Self-contained: sets the tooltip, registers Alt+G, and handles all
+   * open/close/navigation natively.
+   *
+   * Key design choices:
+   *  - Tooltip lives on #fab-tooltip (a wrapper span), not the button, so the
+   *    ::before pseudo-element is never clipped by button styles.
+   *  - Panel is fetched fresh via getPanel() on each interaction rather than
+   *    captured in a closure, avoiding stale references after Datastar morphs.
+   *  - Click-outside uses a document mousedown listener (reliable); focusout is
+   *    only used for keyboard Tab-away, and only when relatedTarget is non-null.
+   */
+  initFab() {
+    const fab     = document.getElementById('fab');
+    const tooltip = document.getElementById('fab-tooltip');
+    if (!fab || fab._fabReady) return;
+    fab._fabReady = true;
+
+    const btn = fab.querySelector('button');
+    if (!btn) { fab._fabReady = false; return; }
+
+    // Always query fresh — avoids stale closure reference if Datastar replaces the node.
+    const getPanel   = () => fab.children[1];
+    const firstInput = () => getPanel()?.querySelector('input:not(:disabled)');
+    const allInputs  = () => [...(getPanel()?.querySelectorAll('input:not(:disabled)') ?? [])];
+    const isOpen     = () => getPanel()?.style.display !== 'none';
+
+    // Remember what was focused before opening so Escape can restore it.
+    // Restoring prevents btn from getting :focus-visible, which would show the tooltip.
+    let preFocusEl = null;
+
+    const open = () => {
+      const panel = getPanel();
+      if (!panel) return;
+      preFocusEl = document.activeElement;
+      panel.style.display = '';
+      btn.setAttribute('aria-expanded', 'true');
+      firstInput()?.focus();
+    };
+
+    // refocus=true (Escape, click-toggle): restore pre-open focus, or blur the button.
+    // refocus=false (focusout, clicked outside): leave focus wherever it went.
+    const close = (refocus = true) => {
+      const panel = getPanel();
+      if (panel) panel.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+      if (refocus) {
+        const target = preFocusEl && preFocusEl !== btn && document.body.contains(preFocusEl)
+          ? preFocusEl : null;
+        if (target) target.focus();
+        else btn.blur();   // blur so :focus-visible never triggers the tooltip
+      }
+      preFocusEl = null;
+    };
+
+    // Tooltip on the wrapper span (data-preserve-attr="data-tip" survives SSE morphs).
+    if (tooltip) tooltip.setAttribute('data-tip', `Settings (${altSymbol}G)`);
+
+    // Click the button to toggle.
+    btn.addEventListener('click', () => isOpen() ? close() : open());
+
+    // Alt+G toggles from anywhere (same rules as the data-accel__alt plugin).
+    window.addEventListener('keydown', (e) => {
+      if (!e.altKey || e.metaKey || e.ctrlKey) return;
+      if (e.code !== 'KeyG') return;
+      if (document.querySelector('#modal-container > *')) return;
+      e.preventDefault();
+      isOpen() ? close() : open();
+    }, true);
+
+    // Keyboard handling inside #fab: Escape closes; arrows navigate inputs.
+    fab.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        close();
+        return;
+      }
+      if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return;
+      const inputs = allInputs();
+      if (!inputs.includes(document.activeElement)) return;
+      e.preventDefault();
+      const idx = inputs.indexOf(document.activeElement);
+      if (e.key === 'ArrowDown') inputs[Math.min(idx + 1, inputs.length - 1)]?.focus();
+      else if (idx > 0) inputs[idx - 1]?.focus();
+      // ArrowUp on first item: already at top, do nothing.
+    });
+
+    // Click outside #fab closes the panel.  Checking e.target on mousedown (before
+    // focus moves) is reliable; focusout is not, because clicking a non-focusable
+    // element like label text produces relatedTarget=null before focus settles.
+    document.addEventListener('mousedown', (e) => {
+      if (isOpen() && !fab.contains(e.target)) close(false);
+    }, true);
+
+    // Keyboard navigation (Tab) out of #fab closes the panel.
+    // Only act when relatedTarget is set — a null relatedTarget means the browser
+    // moved focus to body (e.g. label-text click), which we handle via mousedown above.
+    fab.addEventListener('focusout', (e) => {
+      if (e.relatedTarget && !fab.contains(e.relatedTarget)) close(false);
+    });
+  },
+
+
+
+  /**
    * Keyboard navigation for search result buttons.
    * ArrowDown/Up move focus between result buttons (or back to the search input
    * when Up is pressed on the first result). Escape returns focus to the input.

--- a/src/dialog_tool/skein/ui/app.clj
+++ b/src/dialog_tool/skein/ui/app.clj
@@ -131,9 +131,9 @@
         ok]
        (if (pos? new)
          [:div.bg-warning.text-warning-content.p-2.font-semibold.cursor-pointer
-          {:role          "button"
-           :tabindex      "0"
-           :aria-label    (str new " new knots")
+          {:role "button"
+           :tabindex "0"
+           :aria-label (str new " new knots")
            :data-on:click (h/action {:as "seek-new"}
                                     (actions/seek-status :new))}
           new]
@@ -142,9 +142,9 @@
           new])
        (if (pos? error)
          [:div.bg-error.text-error-content.p-2.font-semibold.rounded-r-lg.cursor-pointer
-          {:role          "button"
-           :tabindex      "0"
-           :aria-label    (str error " error knots")
+          {:role "button"
+           :tabindex "0"
+           :aria-label (str error " error knots")
            :data-on:click (h/action {:as "seek-error"}
                                     (actions/seek-status :error))}
           error]
@@ -152,16 +152,16 @@
           {:aria-label (str error " error knots")}
           error])]
       [:div.flex.items-center.gap-1.shrink-0.ml-auto
-              (dropdown/dropdown {:disabled              (<= (count labeled-knots) 1)
-                                  :label                 (list [:div.icon.icon-jump] [:span.hidden.lg:inline "Jump"])
-                                  :button-class          "btn-primary tooltip tooltip-bottom"
-                                  :data-label            "Jump"
-                                  :data-accel__alt       "j"
-                                  :data-preserve-attr    "data-tip"}
-                                 (for [{:keys [id label]} labeled-knots]
-                                   (dropdown/button {:data-on:click (h/action {:as "jump-to-label"}
-                                                                              (actions/jump-to-label id))}
-                                                    label)))
+       (dropdown/dropdown {:disabled (<= (count labeled-knots) 1)
+                           :label (list [:div.icon.icon-jump] [:span.hidden.lg:inline "Jump"])
+                           :button-class "btn-primary tooltip tooltip-bottom"
+                           :data-label "Jump"
+                           :data-accel__alt "j"
+                           :data-preserve-attr "data-tip"}
+                          (for [{:keys [id label]} labeled-knots]
+                            (dropdown/button {:data-on:click (h/action {:as "jump-to-label"}
+                                                                       (actions/jump-to-label id))}
+                                             label)))
        (navbar-btn {:data-on:click (h/action {:as "replay-all"}
                                              (actions/replay-all))
                     :data-accel__alt__shift "r"}
@@ -187,16 +187,14 @@
                     :disabled (not can-reload?)}
                    "icon-reload" "Reload")
        [:button.btn.btn-primary {:type "button"
-                                  :data-on:click (h/action {:as "quit"}
-                                                           (actions/quit))}
+                                 :data-on:click (h/action {:as "quit"}
+                                                          (actions/quit))}
         [:div.icon.icon-quit {:aria-hidden "true"}] [:span.hidden.lg:inline "Quit"]]]]]))
 
 (def ^:private status->border-class
   {:ok "border-base-300"
    :new "border-warning"
    :error "border-error"})
-
-
 
 (defn- compare-pred
   [left right]
@@ -238,8 +236,8 @@
       (when active?
         [:div.icon.icon-arrow-right {:role "img" :aria-label "Selected"}])
       (case status
-        :new   [:div.icon.icon-warning.w-4.h-4 {:role "img" :aria-label "New knot"}]
-        :error [:div.icon.icon-error.w-4.h-4   {:role "img" :aria-label "Error knot"}]
+        :new [:div.icon.icon-warning.w-4.h-4 {:role "img" :aria-label "New knot"}]
+        :error [:div.icon.icon-error.w-4.h-4 {:role "img" :aria-label "Error knot"}]
         nil)]
      [:div
       {:class (classes "border-x-8 grow cursor-pointer"
@@ -285,23 +283,23 @@
         {:keys [tree debug-enabled?]} session
         active-knot-id (:active-knot-id tree)
         {:keys [id dynamic-response parent-id selected-child-id children unblessed]} (session/get-knot session active-knot-id)
-        root?            (= 0 id)
-        all-ok?          (->> selected-knots
-                              (map :status)
-                              (every? #(= % :ok)))
-        leaf-knot-id     (-> selected-knots last :id)
+        root? (= 0 id)
+        all-ok? (->> selected-knots
+                     (map :status)
+                     (every? #(= % :ok)))
+        leaf-knot-id (-> selected-knots last :id)
         ;; Siblings: other children of parent, sorted alphabetically (matching nav graph order)
-        sorted-siblings  (when-not root?
-                           (->> (tree/find-children tree parent-id)
-                                (sort-by :command)
-                                vec))
-        sibling-idx      (when (seq sorted-siblings)
-                           (first (keep-indexed (fn [i s] (when (= (:id s) id) i))
-                                                sorted-siblings)))
-        prev-sibling-id  (when (and sibling-idx (pos? sibling-idx))
-                           (:id (nth sorted-siblings (dec sibling-idx))))
-        next-sibling-id  (when (and sibling-idx (< sibling-idx (dec (count sorted-siblings))))
-                           (:id (nth sorted-siblings (inc sibling-idx))))]
+        sorted-siblings (when-not root?
+                          (->> (tree/find-children tree parent-id)
+                               (sort-by :command)
+                               vec))
+        sibling-idx (when (seq sorted-siblings)
+                      (first (keep-indexed (fn [i s] (when (= (:id s) id) i))
+                                           sorted-siblings)))
+        prev-sibling-id (when (and sibling-idx (pos? sibling-idx))
+                          (:id (nth sorted-siblings (dec sibling-idx))))
+        next-sibling-id (when (and sibling-idx (< sibling-idx (dec (count sorted-siblings))))
+                          (:id (nth sorted-siblings (inc sibling-idx))))]
     [:div {:class (classes "bg-base-100 text-base-content border-base-200"
                            "px-2 sm:px-4 py-1"
                            "w-full border-b")}
@@ -409,7 +407,7 @@
                                                (actions/toggle-lock id)))}
                    "icon-lock")
       (toolbar-btn {:disabled root?
-                    :data-label      "Insert Parent…"
+                    :data-label "Insert Parent…"
                     :data-accel__alt "i"
                     :data-on:click (when-not root?
                                      (h/action {:as "insert-parent"}
@@ -448,13 +446,19 @@
 (defn- render-fab
   [*session]
   (let [{:keys [debug-enabled? show-dynamic? fixed-width?]} @*session]
-    [:div.fab
-     [:div.btn.btn-lg.btn-circle.btn-primary
-      {:tabindex "0"
-       :role "button"}
-      [:div.icon.icon-globe]]
-
-     [:div.rounded-box.bg-base-100.border.border-base-200.flex.flex-col.items-start
+    [:div#fab
+     {:class "fixed bottom-4 right-4 z-[999] flex flex-col-reverse items-end gap-2 text-sm"
+      :data-init "sk.initFab()"}
+     [:span#fab-tooltip.tooltip.tooltip-left
+      {:data-preserve-attr "data-tip"}
+      [:button.btn.btn-lg.btn-circle.btn-primary
+       {:aria-label "Settings"
+        :aria-haspopup "true"
+        :aria-expanded "false"}
+       [:div.icon.icon-globe]]]
+     [:div.rounded-box.bg-base-100.border.border-base-200.flex.flex-col.items-start.shadow-lg
+      {:style "display:none"
+       :data-preserve-attr "style"}
       [:label.label.p-2
        [:input.toggle {:type "checkbox"
                        :checked fixed-width?


### PR DESCRIPTION
- Replace DaisyUI `.fab` with a custom `#fab` component; panel visibility controlled by JS (`display:none`) rather than CSS `:focus-within`, eliminating focus-timing bugs
- Alt+G accelerator toggles the panel open/closed from anywhere
- Tooltip (`⌥G` / `Alt+G`) on a wrapper span so the `::before` pseudo-element is never clipped by the circular button
- First toggle receives focus when panel opens; Escape restores pre-open focus (prevents `:focus-visible` from accidentally re-showing the tooltip)
- Arrow keys navigate between toggles; ArrowUp at the top is a no-op
- Click-outside handled via `document mousedown` (reliable); Tab-away handled via `focusout` with non-null `relatedTarget` — avoids premature close when clicking label text

🤖 Generated with [ECA](https://eca.dev) (nubank-anthropic/sonnet-4.6)